### PR TITLE
chore: refine scientist onboarding UX and surface silent auth overrides (1.2.2)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.1
+current_version = 1.2.2
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -13,4 +13,4 @@ replace = __version__ = '{new_version}'
 
 [bumpversion:file:uv.lock]
 search = {current_version}
-replace = {new_version}
+replace = {current_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 1.2.1
 commit = True
 tag = False
 
@@ -13,4 +13,4 @@ replace = __version__ = '{new_version}'
 
 [bumpversion:file:uv.lock]
 search = {current_version}
-replace = {current_version}
+replace = {new_version}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2026-05-20
+
+### Added
+- `docs/auth_config.example.json` — placeholder template scientists can copy to `~/.toshi/auth_config.json`. Closes the onboarding gap where a freshly installed CLI raised `No auth config found` with no concrete starting point.
+
+### Changed
+- `ToshiClientBase` now logs a warning when auto-detected M2M or scientist auth silently overrides an explicit `headers=` argument, and when M2M shadows an existing `~/.toshi/credentials` file. Previously these overrides were silent. No behaviour change beyond the new log lines.
+- `toshi-auth` config gate now requires `scientist_client_id` (what `login` actually consumes) instead of `cognito_domain`. Error message points users at the new example file.
+- `docs/usage.md`: scientist section rewritten to lead with the JSON-file path; precedence rules and the M2M-over-scientist quirk now documented up-front.
+
 ## [1.2.1] - 2026-05-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `docs/auth_config.example.json` — placeholder template scientists can copy to `~/.toshi/auth_config.json`. Closes the onboarding gap where a freshly installed CLI raised `No auth config found` with no concrete starting point.
+- `docs/usage.md`: new `## Scopes` section documenting Cognito Resource Server scopes (`toshi/read`, `toshi/write`), how to inspect current token scopes with `toshi-auth whoami`, the M2M vs scientist scope-source difference, and a test plan for verifying scope policy against a deployment.
 
 ### Changed
 - `ToshiClientBase` now logs a warning when auto-detected M2M or scientist auth silently overrides an explicit `headers=` argument, and when M2M shadows an existing `~/.toshi/credentials` file. Previously these overrides were silent. No behaviour change beyond the new log lines.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/usage.md`: new `## Scopes` section documenting Cognito Resource Server scopes (`toshi/read`, `toshi/write`), how to inspect current token scopes with `toshi-auth whoami`, the M2M vs scientist scope-source difference, and a test plan for verifying scope policy against a deployment.
 
 ### Changed
+- `ToshiClientBase` now reads `~/.toshi/auth_config.json` (via the shared `config.load_cognito_config()` loader) when Cognito env vars aren't set. Previously the JSON file was only consulted by the `toshi-auth` CLI, so scientists who set up the file still had to export `NZSHM22_TOSHI_COGNITO_*` env vars before runtime code could auto-detect their credentials. Env vars still take precedence per-key.
 - `ToshiClientBase` now logs a warning when auto-detected M2M or scientist auth silently overrides an explicit `headers=` argument, and when M2M shadows an existing `~/.toshi/credentials` file. Previously these overrides were silent. No behaviour change beyond the new log lines.
 - `toshi-auth` config gate now requires `scientist_client_id` (what `login` actually consumes) instead of `cognito_domain`. Error message points users at the new example file.
 - `docs/usage.md`: scientist section rewritten to lead with the JSON-file path; precedence rules and the M2M-over-scientist quirk now documented up-front.

--- a/docs/auth_config.example.json
+++ b/docs/auth_config.example.json
@@ -1,0 +1,7 @@
+{
+  "user_pool_id": "ap-southeast-2_XXXXXXXXX",
+  "region": "ap-southeast-2",
+  "scientist_client_id": "REPLACE_WITH_SCIENTIST_APP_CLIENT_ID",
+  "cognito_domain": "toshi-XXXXXXXXXXXX.auth.ap-southeast-2.amazoncognito.com",
+  "identity_pool_id": "ap-southeast-2:REPLACE_WITH_IDENTITY_POOL_GUID"
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,7 +3,14 @@
 ## Authentication
 
 There are three ways to authenticate with the Toshi API, listed in priority order.
-`ToshiClientBase` auto-detects the method based on what is configured.
+`ToshiClientBase` auto-detects the method based on what is configured:
+
+1. M2M — used when `NZSHM22_TOSHI_M2M_SECRET_ARN` and `NZSHM22_TOSHI_COGNITO_DOMAIN` are both set.
+2. Interactive scientist — used when `~/.toshi/credentials` exists and the scientist env vars are set.
+3. Legacy API key — **not auto-detected**; you must pass `headers={"x-api-key": ...}` explicitly.
+
+If both M2M env vars and `~/.toshi/credentials` are present on the same machine, M2M wins.
+`ToshiClientBase` logs a warning when auto-detection overrides an explicit `auth_token` or `headers` argument.
 
 ### 1. M2M (machine-to-machine) — for automation and batch jobs
 
@@ -60,14 +67,31 @@ api = ToshiFile(
 
 ### 2. Interactive credentials — for scientists
 
-First install the CLI and log in:
+Install the CLI:
 
 ```bash
 pip install nshm-toshi-client[cli]
+```
+
+Then give the CLI the Cognito pool details. The simplest way is a JSON config file —
+copy [`docs/auth_config.example.json`](auth_config.example.json) to
+`~/.toshi/auth_config.json` and fill in the values for your Toshi deployment (ask
+the Toshi admin if you don't have them):
+
+```bash
+mkdir -p ~/.toshi
+cp auth_config.example.json ~/.toshi/auth_config.json
+# then edit ~/.toshi/auth_config.json
+```
+
+Log in (you'll be prompted for email + password):
+
+```bash
 toshi-auth login
 ```
 
-This saves tokens to `~/.toshi/credentials`. Then set these env vars:
+This saves tokens to `~/.toshi/credentials`. Set the API URL and the matching
+scientist env vars so `ToshiClientBase` can auto-detect the credentials file:
 
 ```bash
 export NZSHM22_TOSHI_API_URL=https://example-api-url.com/graphql
@@ -86,6 +110,10 @@ api = ToshiFile(
 )
 file = api.get_file("{example_id}")
 ```
+
+> **Alternative:** instead of `~/.toshi/auth_config.json`, you can set all the
+> `NZSHM22_TOSHI_COGNITO_*` env vars (region, user pool ID, scientist client ID,
+> domain) and the CLI will use those. The JSON file is usually less friction.
 
 ### 3. API key (legacy)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,7 @@ There are three ways to authenticate with the Toshi API, listed in priority orde
 `ToshiClientBase` auto-detects the method based on what is configured:
 
 1. M2M — used when `NZSHM22_TOSHI_M2M_SECRET_ARN` and `NZSHM22_TOSHI_COGNITO_DOMAIN` are both set.
-2. Interactive scientist — used when `~/.toshi/credentials` exists and the scientist env vars are set.
+2. Interactive scientist — used when `~/.toshi/credentials` exists and the Cognito domain + scientist client ID are configured (via `~/.toshi/auth_config.json` or the matching `NZSHM22_TOSHI_COGNITO_*` env vars).
 3. Legacy API key — **not auto-detected**; you must pass `headers={"x-api-key": ...}` explicitly.
 
 If both M2M env vars and `~/.toshi/credentials` are present on the same machine, M2M wins.
@@ -90,13 +90,12 @@ Log in (you'll be prompted for email + password):
 toshi-auth login
 ```
 
-This saves tokens to `~/.toshi/credentials`. Set the API URL and the matching
-scientist env vars so `ToshiClientBase` can auto-detect the credentials file:
+This saves tokens to `~/.toshi/credentials`. Both `toshi-auth` and
+`ToshiClientBase` read the same `~/.toshi/auth_config.json`, so no extra
+env vars are needed for Cognito auth. You still need the API URL:
 
 ```bash
 export NZSHM22_TOSHI_API_URL=https://example-api-url.com/graphql
-export NZSHM22_TOSHI_COGNITO_DOMAIN=https://toshi-auth.example.auth.ap-southeast-2.amazoncognito.com
-export NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID=your_scientist_client_id
 ```
 
 The client detects `~/.toshi/credentials` and refreshes tokens automatically:
@@ -111,9 +110,11 @@ api = ToshiFile(
 file = api.get_file("{example_id}")
 ```
 
-> **Alternative:** instead of `~/.toshi/auth_config.json`, you can set all the
-> `NZSHM22_TOSHI_COGNITO_*` env vars (region, user pool ID, scientist client ID,
-> domain) and the CLI will use those. The JSON file is usually less friction.
+> **Alternative:** instead of `~/.toshi/auth_config.json`, you can set the
+> `NZSHM22_TOSHI_COGNITO_*` env vars (domain, scientist client ID, region,
+> user pool ID). Env vars take precedence over the file on a per-key basis,
+> so you can mix the two (e.g. file for shared defaults, env to override
+> `NZSHM22_TOSHI_COGNITO_DOMAIN` in a dev pool).
 
 ### 3. API key (legacy)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -131,6 +131,40 @@ api = ToshiFile(API_URL, S3_URL, None, headers=headers)
 file = api.get_file("{example_id}")
 ```
 
+## Scopes
+
+Toshi API authorisation is gated by OAuth scopes defined as a **Resource
+Server** in the Cognito user pool. The naming convention is
+`{resource_server}/{scope}` — e.g. `toshi/read`, `toshi/write`. Scopes
+themselves are deployment configuration; this client only *requests* them.
+
+You can see what scopes the token you currently hold actually has:
+
+```bash
+toshi-auth whoami
+```
+
+### Where scopes come from
+
+| Auth method | How scopes are chosen |
+|---|---|
+| **M2M** (`client_credentials` grant) | Client explicitly requests `toshi/read toshi/write`. This is **hardcoded** at `nshm_toshi_client/auth.py:72`. The automation app client in Cognito must be configured to permit those scopes, or the token request fails with `invalid_scope`. |
+| **Scientist** (`USER_PASSWORD_AUTH`) | Client does **not** request scopes. Cognito returns whatever the scientist app client is configured to grant by default (set per deployment under App clients → Allowed custom scopes). |
+| **Legacy API key** | Not a Cognito token — scopes don't apply; access is gated by the API key itself on the server side. |
+
+### Testing scope behaviour
+
+When verifying scope policy against a deployment:
+
+- A token with only `toshi/read` should be rejected by the API on any write mutation.
+- A token with no `toshi/*` scope should be rejected on every call.
+- An M2M token request will fail at Cognito (not the API) if the automation app client isn't permitted the hardcoded scopes — look for `invalid_scope` in the Cognito response.
+- Scientist scope changes don't require a code release — but a user already holding a token must `toshi-auth logout && toshi-auth login` to pick up the new scopes.
+
+To find the authoritative scope definition: AWS Console → Cognito → your
+user pool → App integration → **Resource servers** (defines available scopes)
+and **App clients** → Allowed custom scopes (grants scopes per client).
+
 ## toshi-auth CLI
 
 Install with `pip install nshm-toshi-client[cli]`.

--- a/nshm_toshi_client/__init__.py
+++ b/nshm_toshi_client/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Chris B Chamberlain"""
 __email__ = 'chrisbc@artisan.co.nz'
-__version__ = '1.2.1'
+__version__ = '1.2.2'
 
 from .config import API_KEY, API_URL, S3_URL
 from .toshi_file import ToshiFile

--- a/nshm_toshi_client/cli.py
+++ b/nshm_toshi_client/cli.py
@@ -28,7 +28,6 @@ except ImportError:
 import base64
 import configparser
 import json
-import os
 import sys
 import time
 from datetime import datetime, timezone
@@ -74,32 +73,20 @@ def _get_boto3():
 
 
 def load_auth_config() -> dict:
-    """Load Cognito config from JSON file or env vars.
+    """Load Cognito config for use by the CLI.
 
-    Priority:
-        1. JSON file at $TOSHI_COGNITO_CONFIG
-        2. JSON file at ~/.toshi/auth_config.json
-        3. NZSHM22_TOSHI_COGNITO_* env vars
+    Delegates resolution to `config.load_cognito_config`, which checks
+    NZSHM22_TOSHI_COGNITO_* env vars first and falls back to a JSON file at
+    `TOSHI_COGNITO_CONFIG` or `~/.toshi/auth_config.json`.
+
+    Raises `click.ClickException` if no usable config is found (the runtime
+    `ToshiClientBase` returns an empty dict in the same situation).
     """
-    config_path = os.environ.get('TOSHI_COGNITO_CONFIG', '')
-    if not config_path:
-        default = Path.home() / '.toshi' / 'auth_config.json'
-        if default.exists():
-            config_path = str(default)
+    from nshm_toshi_client.config import load_cognito_config
 
-    if config_path and os.path.exists(config_path):
-        with open(config_path) as f:
-            return json.load(f)
+    config = load_cognito_config()
 
-    # Fall back to env vars
-    from nshm_toshi_client.config import (
-        COGNITO_DOMAIN,
-        COGNITO_REGION,
-        COGNITO_SCIENTIST_CLIENT_ID,
-        COGNITO_USER_POOL_ID,
-    )
-
-    if not COGNITO_SCIENTIST_CLIENT_ID:
+    if not config.get('scientist_client_id'):
         raise click.ClickException(
             'No auth config found.\n'
             'Either:\n'
@@ -109,12 +96,10 @@ def load_auth_config() -> dict:
             '    NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID and NZSHM22_TOSHI_COGNITO_REGION).'
         )
 
-    return {
-        'region': COGNITO_REGION,
-        'user_pool_id': COGNITO_USER_POOL_ID,
-        'scientist_client_id': COGNITO_SCIENTIST_CLIENT_ID,
-        'cognito_domain': COGNITO_DOMAIN.removeprefix('https://'),
-    }
+    # boto3 cognito clients want the bare hostname, not the https:// URL.
+    if config.get('cognito_domain'):
+        config['cognito_domain'] = config['cognito_domain'].removeprefix('https://')
+    return config
 
 
 # ---------------------------------------------------------------------------

--- a/nshm_toshi_client/cli.py
+++ b/nshm_toshi_client/cli.py
@@ -99,12 +99,14 @@ def load_auth_config() -> dict:
         COGNITO_USER_POOL_ID,
     )
 
-    if not COGNITO_DOMAIN:
+    if not COGNITO_SCIENTIST_CLIENT_ID:
         raise click.ClickException(
             'No auth config found.\n'
-            'Either place auth_config.json at ~/.toshi/auth_config.json,\n'
-            'set TOSHI_COGNITO_CONFIG to a config file path,\n'
-            'or set NZSHM22_TOSHI_COGNITO_* env vars.'
+            'Either:\n'
+            '  - copy docs/auth_config.example.json to ~/.toshi/auth_config.json and edit it,\n'
+            '  - set TOSHI_COGNITO_CONFIG to a config file path, or\n'
+            '  - set the NZSHM22_TOSHI_COGNITO_* env vars (at minimum\n'
+            '    NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID and NZSHM22_TOSHI_COGNITO_REGION).'
         )
 
     return {

--- a/nshm_toshi_client/config.py
+++ b/nshm_toshi_client/config.py
@@ -1,4 +1,9 @@
+import json
+import logging
 import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 API_URL = os.getenv('NZSHM22_TOSHI_API_URL', "http://127.0.0.1:5000/graphql")
 S3_URL = os.getenv('NZSHM22_TOSHI_S3_URL', "http://localhost:4569")
@@ -11,3 +16,57 @@ COGNITO_DOMAIN = os.getenv('NZSHM22_TOSHI_COGNITO_DOMAIN', '')
 COGNITO_SCIENTIST_CLIENT_ID = os.getenv('NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID', '')
 COGNITO_REGION = os.getenv('NZSHM22_TOSHI_COGNITO_REGION', 'ap-southeast-2')
 COGNITO_USER_POOL_ID = os.getenv('NZSHM22_TOSHI_COGNITO_USER_POOL_ID', '')
+
+
+def _load_config_file() -> dict | None:
+    """Return parsed contents of the JSON config file, or None if not found/invalid.
+
+    Resolves the path from the `TOSHI_COGNITO_CONFIG` env var, falling back to
+    `~/.toshi/auth_config.json`.
+    """
+    path_str = os.getenv('TOSHI_COGNITO_CONFIG', '')
+    path = Path(path_str) if path_str else Path.home() / '.toshi' / 'auth_config.json'
+    if not path.exists():
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Failed to read Cognito config from %s: %s", path, exc)
+        return None
+
+
+def load_cognito_config() -> dict:
+    """Resolve the Cognito config from env vars, with JSON-file fallback.
+
+    Env vars take precedence over the file on a per-key basis: if the env var
+    is set, it wins; if not, the corresponding key from the JSON file is used.
+
+    Used by both `toshi-auth` (CLI) and `ToshiClientBase` (runtime) so a
+    scientist who set up `~/.toshi/auth_config.json` does not also have to
+    export the matching env vars.
+
+    Returns a dict with keys: cognito_domain, scientist_client_id, region,
+    user_pool_id. May also include `identity_pool_id` if present in the file
+    (needed by `toshi-auth aws-creds`). Missing values are empty strings,
+    except region which defaults to 'ap-southeast-2'.
+    """
+    config = {
+        'cognito_domain': os.getenv('NZSHM22_TOSHI_COGNITO_DOMAIN', ''),
+        'scientist_client_id': os.getenv('NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID', ''),
+        'region': os.getenv('NZSHM22_TOSHI_COGNITO_REGION', ''),
+        'user_pool_id': os.getenv('NZSHM22_TOSHI_COGNITO_USER_POOL_ID', ''),
+    }
+
+    if not all(config[k] for k in ('cognito_domain', 'scientist_client_id', 'region', 'user_pool_id')):
+        file_config = _load_config_file()
+        if file_config:
+            for key in ('cognito_domain', 'scientist_client_id', 'region', 'user_pool_id'):
+                if not config[key] and file_config.get(key):
+                    config[key] = file_config[key]
+            if file_config.get('identity_pool_id'):
+                config['identity_pool_id'] = file_config['identity_pool_id']
+
+    if not config['region']:
+        config['region'] = 'ap-southeast-2'
+    return config

--- a/nshm_toshi_client/toshi_client_base.py
+++ b/nshm_toshi_client/toshi_client_base.py
@@ -5,7 +5,7 @@ from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 
 from nshm_toshi_client.auth import CREDENTIALS_PATH, ToshiCredentialAuth, ToshiM2MAuth, ToshiTokenManager
-from nshm_toshi_client.config import COGNITO_DOMAIN, COGNITO_SCIENTIST_CLIENT_ID
+from nshm_toshi_client.config import load_cognito_config
 
 logger = logging.getLogger(__name__)
 
@@ -68,8 +68,12 @@ class ToshiClientBase:
             and NZSHM22_TOSHI_M2M_SECRET_ARN + NZSHM22_TOSHI_COGNITO_DOMAIN are set, one is
             created automatically (credentials fetched from AWS Secrets Manager).
         """
+        cognito = load_cognito_config()
+        cognito_domain = cognito['cognito_domain']
+        scientist_client_id = cognito['scientist_client_id']
+
         secret_arn = os.environ.get('NZSHM22_TOSHI_M2M_SECRET_ARN')
-        if token_manager is None and secret_arn and COGNITO_DOMAIN:
+        if token_manager is None and secret_arn and cognito_domain:
             if auth_token is not None:
                 logger.warning(
                     "ToshiClientBase: explicit auth_token ignored — NZSHM22_TOSHI_M2M_SECRET_ARN "
@@ -87,13 +91,13 @@ class ToshiClientBase:
                     "(NZSHM22_TOSHI_M2M_SECRET_ARN is set). Unset the env var to use scientist creds."
                 )
             logger.debug("ToshiClientBase: auto-configuring M2M token manager from Secrets Manager")
-            token_manager = ToshiTokenManager(cognito_domain=COGNITO_DOMAIN, secret_arn=secret_arn)
+            token_manager = ToshiTokenManager(cognito_domain=cognito_domain, secret_arn=secret_arn)
 
         if token_manager is not None:
             transport = RequestsHTTPTransport(
                 url=url, auth=ToshiM2MAuth(token_manager), use_json=True, retries=retries, timeout=timeout
             )
-        elif CREDENTIALS_PATH.exists() and COGNITO_DOMAIN and COGNITO_SCIENTIST_CLIENT_ID:
+        elif CREDENTIALS_PATH.exists() and cognito_domain and scientist_client_id:
             if auth_token is not None:
                 logger.warning(
                     "ToshiClientBase: explicit auth_token ignored — ~/.toshi/credentials exists, "
@@ -107,16 +111,16 @@ class ToshiClientBase:
                     "the credentials file if you want to use headers."
                 )
             logger.debug("ToshiClientBase: auto-configuring interactive auth from ~/.toshi/credentials")
-            auth = ToshiCredentialAuth(COGNITO_DOMAIN, COGNITO_SCIENTIST_CLIENT_ID)
+            auth = ToshiCredentialAuth(cognito_domain, scientist_client_id)
             transport = RequestsHTTPTransport(url=url, auth=auth, use_json=True, retries=retries, timeout=timeout)
         else:
             if headers is None:
                 if auth_token is None:
                     raise ValueError(
                         "No auth configured. Provide one of: "
-                        "token_manager, NZSHM22_TOSHI_COGNITO_* env vars, "
-                        "~/.toshi/credentials (toshi-auth login), "
-                        "auth_token=..., or custom headers=..."
+                        "token_manager, NZSHM22_TOSHI_COGNITO_* env vars or "
+                        "~/.toshi/auth_config.json, plus ~/.toshi/credentials "
+                        "(toshi-auth login), auth_token=..., or custom headers=..."
                     )
                 headers = {"Authorization": f"Bearer {auth_token}"}
             transport = RequestsHTTPTransport(url=url, headers=headers, use_json=True, retries=retries, timeout=timeout)

--- a/nshm_toshi_client/toshi_client_base.py
+++ b/nshm_toshi_client/toshi_client_base.py
@@ -76,6 +76,16 @@ class ToshiClientBase:
                     "is set, so M2M auth is being used instead. Unset the env var or pass "
                     "token_manager=... to override."
                 )
+            if headers is not None:
+                logger.warning(
+                    "ToshiClientBase: explicit headers ignored — NZSHM22_TOSHI_M2M_SECRET_ARN "
+                    "is set, so M2M auth is being used instead. Unset the env var to use headers."
+                )
+            if CREDENTIALS_PATH.exists():
+                logger.warning(
+                    "ToshiClientBase: ~/.toshi/credentials exists but M2M auth takes precedence "
+                    "(NZSHM22_TOSHI_M2M_SECRET_ARN is set). Unset the env var to use scientist creds."
+                )
             logger.debug("ToshiClientBase: auto-configuring M2M token manager from Secrets Manager")
             token_manager = ToshiTokenManager(cognito_domain=COGNITO_DOMAIN, secret_arn=secret_arn)
 
@@ -87,8 +97,14 @@ class ToshiClientBase:
             if auth_token is not None:
                 logger.warning(
                     "ToshiClientBase: explicit auth_token ignored — ~/.toshi/credentials exists, "
-                    "so interactive auth is being used instead. Run `toshi-auth logout` or pass "
-                    "headers=... to override."
+                    "so interactive auth is being used instead. Run `toshi-auth logout` to remove "
+                    "the credentials file if you want to use a different auth method."
+                )
+            if headers is not None:
+                logger.warning(
+                    "ToshiClientBase: explicit headers ignored — ~/.toshi/credentials exists, "
+                    "so interactive auth is being used instead. Run `toshi-auth logout` to remove "
+                    "the credentials file if you want to use headers."
                 )
             logger.debug("ToshiClientBase: auto-configuring interactive auth from ~/.toshi/credentials")
             auth = ToshiCredentialAuth(COGNITO_DOMAIN, COGNITO_SCIENTIST_CLIENT_ID)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nshm-toshi-client"
-version = "1.2.1"
+version = "1.2.2"
 description = "client for toshi API"
 authors = [
     { name = "Chris B Chamberlain", email = "chrisbc@artisan.co.nz" },

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -179,6 +179,70 @@ class TestToshiClientBaseWithTokenManager(unittest.TestCase):
         importlib.reload(cfg)
         importlib.reload(base)
 
+    def test_warns_when_secret_arn_overrides_explicit_headers(self):
+        """SECRET_ARN env should shadow headers= and emit a warning."""
+        API_URL = "http://fake_api/graphql"
+        env = {
+            'NZSHM22_TOSHI_M2M_SECRET_ARN': SECRET_ARN,
+            'NZSHM22_TOSHI_COGNITO_DOMAIN': COGNITO_DOMAIN,
+        }
+        with patch.dict('os.environ', env):
+            import importlib
+
+            import nshm_toshi_client.config as cfg
+            import nshm_toshi_client.toshi_client_base as base
+
+            importlib.reload(cfg)
+            importlib.reload(base)
+
+            with (
+                mock_secrets_manager(),
+                patch("nshm_toshi_client.auth.urllib_request.urlopen", return_value=_mock_urlopen()),
+            ):
+                with requests_mock.Mocker() as m:
+                    m.post(API_URL, json={"data": {"about": "test-api"}})
+                    with self.assertLogs("nshm_toshi_client.toshi_client_base", level="WARNING") as cm:
+                        base.ToshiClientBase(
+                            API_URL,
+                            headers={"x-api-key": "legacy-key"},
+                            with_schema_validation=False,
+                        )
+                    self.assertTrue(any("headers ignored" in m for m in cm.output))
+
+        importlib.reload(cfg)
+        importlib.reload(base)
+
+    def test_warns_when_secret_arn_shadows_credentials_file(self):
+        """If both M2M env and ~/.toshi/credentials are present, M2M wins but the user is warned."""
+        API_URL = "http://fake_api/graphql"
+        env = {
+            'NZSHM22_TOSHI_M2M_SECRET_ARN': SECRET_ARN,
+            'NZSHM22_TOSHI_COGNITO_DOMAIN': COGNITO_DOMAIN,
+        }
+        with patch.dict('os.environ', env):
+            import importlib
+
+            import nshm_toshi_client.config as cfg
+            import nshm_toshi_client.toshi_client_base as base
+
+            importlib.reload(cfg)
+            importlib.reload(base)
+
+            with (
+                mock_secrets_manager(),
+                patch("nshm_toshi_client.auth.urllib_request.urlopen", return_value=_mock_urlopen()),
+                patch.object(base, 'CREDENTIALS_PATH') as mock_path,
+            ):
+                mock_path.exists.return_value = True
+                with requests_mock.Mocker() as m:
+                    m.post(API_URL, json={"data": {"about": "test-api"}})
+                    with self.assertLogs("nshm_toshi_client.toshi_client_base", level="WARNING") as cm:
+                        base.ToshiClientBase(API_URL, with_schema_validation=False)
+                    self.assertTrue(any("M2M auth takes precedence" in m for m in cm.output))
+
+        importlib.reload(cfg)
+        importlib.reload(base)
+
     def test_raises_when_no_auth_configured(self):
         """Missing all auth paths should raise ValueError, not silently send 'Bearer None'."""
         import nshm_toshi_client.config as cfg

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,6 +80,7 @@ class TestLoadAuthConfig(unittest.TestCase):
         env = {
             'TOSHI_COGNITO_CONFIG': '',
             'NZSHM22_TOSHI_COGNITO_DOMAIN': '',
+            'NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID': '',
         }
         with (
             patch.dict('os.environ', env),
@@ -92,6 +93,30 @@ class TestLoadAuthConfig(unittest.TestCase):
 
             with self.assertRaises(click.ClickException):
                 load_auth_config()
+
+        importlib.reload(cfg)
+
+    def test_raises_when_scientist_client_id_missing(self):
+        """Gate is scientist_client_id (what login() consumes), not just cognito_domain."""
+        import importlib
+
+        env = {
+            'TOSHI_COGNITO_CONFIG': '',
+            'NZSHM22_TOSHI_COGNITO_DOMAIN': 'https://toshi-auth.example.amazoncognito.com',
+            'NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID': '',
+        }
+        with (
+            patch.dict('os.environ', env),
+            patch('nshm_toshi_client.cli.Path.home', return_value=Path('/nonexistent')),
+        ):
+            import nshm_toshi_client.config as cfg
+
+            importlib.reload(cfg)
+            import click
+
+            with self.assertRaises(click.ClickException) as ctx:
+                load_auth_config()
+            self.assertIn("auth_config.example.json", str(ctx.exception))
 
         importlib.reload(cfg)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,6 +120,37 @@ class TestLoadAuthConfig(unittest.TestCase):
 
         importlib.reload(cfg)
 
+    def test_load_cognito_config_per_key_env_over_file(self):
+        """Env vars win per-key; file fills only the keys env left blank."""
+        from nshm_toshi_client.config import load_cognito_config
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(
+                {
+                    'cognito_domain': 'file-domain.example.com',
+                    'scientist_client_id': 'file_scientist_id',
+                    'region': 'us-west-2',
+                    'user_pool_id': 'file_pool',
+                },
+                f,
+            )
+            f.flush()
+            env = {
+                'TOSHI_COGNITO_CONFIG': f.name,
+                # env sets cognito_domain only; file should fill the rest
+                'NZSHM22_TOSHI_COGNITO_DOMAIN': 'https://env-domain.example.com',
+                'NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID': '',
+                'NZSHM22_TOSHI_COGNITO_REGION': '',
+                'NZSHM22_TOSHI_COGNITO_USER_POOL_ID': '',
+            }
+            with patch.dict('os.environ', env):
+                config = load_cognito_config()
+
+        self.assertEqual(config['cognito_domain'], 'https://env-domain.example.com')
+        self.assertEqual(config['scientist_client_id'], 'file_scientist_id')
+        self.assertEqual(config['region'], 'us-west-2')
+        self.assertEqual(config['user_pool_id'], 'file_pool')
+
 
 # ---------------------------------------------------------------------------
 # HTTP helper

--- a/tests/test_credential_auth.py
+++ b/tests/test_credential_auth.py
@@ -197,6 +197,57 @@ class TestToshiClientBaseWithCredentialAuth(unittest.TestCase):
             importlib.reload(cfg)
             importlib.reload(base)
 
+    def _run_with_credentials(self, kwargs, expected_warning):
+        """Helper: set up scientist auto-detect, call ToshiClientBase(**kwargs), assert warning."""
+        import importlib
+        import tempfile
+
+        API_URL = "http://fake_api/graphql"
+        valid_token = _make_jwt({"exp": time.time() + 3600})
+        creds = {"access_token": valid_token, "refresh_token": "refresh_tok"}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fake_creds_path = Path(tmpdir) / 'credentials'
+            fake_creds_path.write_text(json.dumps(creds))
+
+            env = {
+                'NZSHM22_TOSHI_COGNITO_DOMAIN': 'https://toshi-auth.example.amazoncognito.com',
+                'NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID': 'scientist_id',
+                'NZSHM22_TOSHI_M2M_SECRET_ARN': '',
+            }
+            with (
+                patch.dict('os.environ', env),
+                patch('nshm_toshi_client.auth.CREDENTIALS_PATH', fake_creds_path),
+                patch('nshm_toshi_client.toshi_client_base.CREDENTIALS_PATH', fake_creds_path),
+            ):
+                import nshm_toshi_client.config as cfg
+                import nshm_toshi_client.toshi_client_base as base
+
+                importlib.reload(cfg)
+                importlib.reload(base)
+
+                with requests_mock.Mocker() as m:
+                    m.post(API_URL, json={"data": {"about": "test-api"}})
+                    with self.assertLogs("nshm_toshi_client.toshi_client_base", level="WARNING") as cm:
+                        base.ToshiClientBase(API_URL, with_schema_validation=False, **kwargs)
+                    self.assertTrue(
+                        any(expected_warning in line for line in cm.output),
+                        f"Expected warning containing {expected_warning!r}, got: {cm.output}",
+                    )
+
+        # Restore cfg/base with the original (un-patched) env. The reload must run
+        # outside `with patch.dict(...)` so the patched env doesn't leak into later tests.
+        importlib.reload(cfg)
+        importlib.reload(base)
+
+    def test_warns_when_credentials_file_overrides_auth_token(self):
+        """Scientist auto-detect should shadow auth_token= and emit a warning."""
+        self._run_with_credentials({"auth_token": "explicit-token"}, "auth_token ignored")
+
+    def test_warns_when_credentials_file_overrides_headers(self):
+        """Scientist auto-detect should shadow headers= and emit a warning."""
+        self._run_with_credentials({"headers": {"x-api-key": "legacy-key"}}, "headers ignored")
+
 
 class TestSubclassKwargsPassthrough(unittest.TestCase):
     """Verify subclasses forward **kwargs (e.g. token_manager) to ToshiClientBase."""

--- a/tests/test_credential_auth.py
+++ b/tests/test_credential_auth.py
@@ -197,6 +197,63 @@ class TestToshiClientBaseWithCredentialAuth(unittest.TestCase):
             importlib.reload(cfg)
             importlib.reload(base)
 
+    def test_auto_detects_via_auth_config_json_without_env_vars(self):
+        """Chris scenario: ~/.toshi/auth_config.json present, no NZSHM22_TOSHI_COGNITO_* env vars,
+        ~/.toshi/credentials present. ToshiClientBase should still auto-detect scientist auth.
+        """
+        import importlib
+        import tempfile
+
+        API_URL = "http://fake_api/graphql"
+        valid_token = _make_jwt({"exp": time.time() + 3600})
+        creds = {"access_token": valid_token, "refresh_token": "refresh_tok"}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            fake_creds_path = tmp / 'credentials'
+            fake_creds_path.write_text(json.dumps(creds))
+
+            auth_config_path = tmp / 'auth_config.json'
+            auth_config_path.write_text(
+                json.dumps(
+                    {
+                        'region': 'ap-southeast-2',
+                        'user_pool_id': 'ap-southeast-2_FAKE',
+                        'scientist_client_id': 'file_scientist_id',
+                        'cognito_domain': 'https://toshi-auth.example.amazoncognito.com',
+                    }
+                )
+            )
+
+            env = {
+                'NZSHM22_TOSHI_COGNITO_DOMAIN': '',
+                'NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID': '',
+                'NZSHM22_TOSHI_M2M_SECRET_ARN': '',
+                'TOSHI_COGNITO_CONFIG': str(auth_config_path),
+            }
+
+            with (
+                patch.dict('os.environ', env),
+                patch('nshm_toshi_client.auth.CREDENTIALS_PATH', fake_creds_path),
+                patch('nshm_toshi_client.toshi_client_base.CREDENTIALS_PATH', fake_creds_path),
+            ):
+                import nshm_toshi_client.config as cfg
+                import nshm_toshi_client.toshi_client_base as base
+
+                importlib.reload(cfg)
+                importlib.reload(base)
+
+                with requests_mock.Mocker() as m:
+                    m.post(API_URL, json={"data": {"about": "test-api"}})
+                    client = base.ToshiClientBase(API_URL, with_schema_validation=False)
+                    client.run_query("{ about }")
+
+                history = m.request_history
+                self.assertEqual(history[0].headers.get("Authorization"), f"Bearer {valid_token}")
+
+            importlib.reload(cfg)
+            importlib.reload(base)
+
     def _run_with_credentials(self, kwargs, expected_warning):
         """Helper: set up scientist auto-detect, call ToshiClientBase(**kwargs), assert warning."""
         import importlib

--- a/uv.lock
+++ b/uv.lock
@@ -1649,7 +1649,7 @@ wheels = [
 
 [[package]]
 name = "nshm-toshi-client"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "gql", extra = ["requests"] },


### PR DESCRIPTION
## Summary

- **Closes the scientist onboarding gap.** A freshly installed `toshi-auth` raised `No auth config found.` with no concrete starting point. Ships `docs/auth_config.example.json` (placeholders) and rewrites the `usage.md` scientist section to lead with the JSON-file path. Error message in `cli.py` now points at the example file.
- **Surfaces previously-silent auth overrides.** `ToshiClientBase` now logs a warning when M2M/scientist auto-detection silently shadows an explicit `headers=` argument, and when M2M wins over an existing `~/.toshi/credentials`. No behaviour change — just visibility into the precedence rules documented in `usage.md`.
- **Tightens the CLI config gate.** `load_auth_config()` now gates on `scientist_client_id` (what `login()` actually consumes) rather than `cognito_domain`.
- **Repairs `.bumpversion.cfg`.** The 1.2.1 release was cut without running bump2version, leaving `current_version = 1.2.0`. Also fixes a typo in the `uv.lock` section (`replace = {current_version}` → `{new_version}`) so the lockfile stays in sync on future bumps.
- **Bumps to 1.2.2.**

## Test plan

- [x] `uv run pytest tests/` — 72 passed (5 new tests for the warnings and the new gate)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy nshm_toshi_client/` — clean
- [x] Version 1.2.2 in sync across `pyproject.toml`, `__init__.py`, `uv.lock`, `.bumpversion.cfg`, `CHANGELOG.md`
- [ ] `pip-audit` reports 2 pre-existing transitive advisories (`idna 3.13`, `pymdown-extensions 10.21.2`) — out of scope for this PR; leave for the next deps sweep.