### PR TITLE
fix: send id_token to Identity Pool; always load auth_config.json for…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- `cli.get_aws_credentials()` passes `id_token` to `GetId` / `GetCredentialsForIdentity` Logins instead of `access_token`.
+- All Cognito keys try env first and fall back to `~/.toshi/auth_config.json` file.
+
+### Added
+- `NZSHM22_TOSHI_COGNITO_IDENTITY_POOL_ID` env var so that `~/.toshi/auth_config.json` is not required.
+
 ## [1.2.3] - 2026-05-22
 
 ### Added

--- a/nshm_toshi_client/cli.py
+++ b/nshm_toshi_client/cli.py
@@ -187,8 +187,14 @@ def refresh_token(config: dict, refresh_tok: str) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def get_aws_credentials(config: dict, access_token: str, profile: str = 'toshi') -> str:
-    """Exchange Cognito token for AWS STS credentials via Identity Pool."""
+def get_aws_credentials(config: dict, id_token: str, profile: str = 'toshi') -> str:
+    """Exchange Cognito id_token for AWS STS credentials via Identity Pool.
+
+    The id_token (not the access_token) must be used here: Cognito Identity
+    Pools validate the ``aud`` claim in the Logins map, and access tokens omit
+    ``aud`` (they carry ``client_id`` instead).  See AWS docs:
+    https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-identity.html#enhanced-flow
+    """
     boto3 = _get_boto3()
 
     region = config['region']
@@ -203,7 +209,7 @@ def get_aws_credentials(config: dict, access_token: str, profile: str = 'toshi')
     resp = cognito_identity.get_id(
         IdentityPoolId=identity_pool_id,
         Logins={
-            f'cognito-idp.{region}.amazonaws.com/{config["user_pool_id"]}': access_token,
+            f'cognito-idp.{region}.amazonaws.com/{config["user_pool_id"]}': id_token,
         },
     )
     identity_id = resp['IdentityId']
@@ -213,7 +219,7 @@ def get_aws_credentials(config: dict, access_token: str, profile: str = 'toshi')
     resp = cognito_identity.get_credentials_for_identity(
         IdentityId=identity_id,
         Logins={
-            f'cognito-idp.{region}.amazonaws.com/{config["user_pool_id"]}': access_token,
+            f'cognito-idp.{region}.amazonaws.com/{config["user_pool_id"]}': id_token,
         },
     )
 
@@ -310,6 +316,7 @@ def token(raw):
             token_resp = refresh_token(config, refresh_tok)
             access_token = token_resp['access_token']
             creds['access_token'] = access_token
+            creds['id_token'] = token_resp.get('id_token', '')
             creds['expires_at'] = time.time() + token_resp.get('expires_in', 3600)
             if 'refresh_token' in token_resp:
                 creds['refresh_token'] = token_resp['refresh_token']
@@ -363,19 +370,20 @@ def aws_creds(profile):
     config = load_auth_config()
     creds = load_credentials()
 
-    access_token = creds.get('access_token', '')
-    if not access_token:
+    id_token = creds.get('id_token', '')
+    if not id_token:
         raise click.ClickException('Not logged in. Run: toshi-auth login')
 
-    if is_token_expired(access_token, buffer_seconds=300):
+    if is_token_expired(id_token, buffer_seconds=300):
         refresh_tok = creds.get('refresh_token', '')
         if not refresh_tok:
             raise click.ClickException('Token expired and no refresh token. Run: toshi-auth login')
         click.echo('Token expired, refreshing...', err=True)
         try:
             token_resp = refresh_token(config, refresh_tok)
-            access_token = token_resp['access_token']
-            creds['access_token'] = access_token
+            creds['access_token'] = token_resp['access_token']
+            id_token = token_resp.get('id_token', '')
+            creds['id_token'] = id_token
             creds['expires_at'] = time.time() + token_resp.get('expires_in', 3600)
             if 'refresh_token' in token_resp:
                 creds['refresh_token'] = token_resp['refresh_token']
@@ -383,7 +391,7 @@ def aws_creds(profile):
         except Exception as e:
             raise click.ClickException(f'Token refresh failed: {e}. Run: toshi-auth login') from None
 
-    result_profile = get_aws_credentials(config, access_token, profile)
+    result_profile = get_aws_credentials(config, id_token, profile)
 
     click.echo(f'\nAWS credentials saved to profile [{result_profile}] in ~/.aws/credentials')
     click.echo(f'Use with: export AWS_PROFILE={result_profile}')

--- a/nshm_toshi_client/cli.py
+++ b/nshm_toshi_client/cli.py
@@ -188,13 +188,7 @@ def refresh_token(config: dict, refresh_tok: str) -> dict:
 
 
 def get_aws_credentials(config: dict, id_token: str, profile: str = 'toshi') -> str:
-    """Exchange Cognito id_token for AWS STS credentials via Identity Pool.
-
-    The id_token (not the access_token) must be used here: Cognito Identity
-    Pools validate the ``aud`` claim in the Logins map, and access tokens omit
-    ``aud`` (they carry ``client_id`` instead).  See AWS docs:
-    https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-identity.html#enhanced-flow
-    """
+    """Exchange Cognito id_token for AWS STS credentials via Identity Pool."""
     boto3 = _get_boto3()
 
     region = config['region']

--- a/nshm_toshi_client/config.py
+++ b/nshm_toshi_client/config.py
@@ -87,19 +87,19 @@ def load_cognito_config() -> dict:
     user_pool_id, identity_pool_id. Missing values are empty strings, except
     region which defaults to 'ap-southeast-2'.
     """
-    _ENV_KEYS = {
+    env_keys = {
         'cognito_domain': 'NZSHM22_TOSHI_COGNITO_DOMAIN',
         'scientist_client_id': 'NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID',
         'region': 'NZSHM22_TOSHI_COGNITO_REGION',
         'user_pool_id': 'NZSHM22_TOSHI_COGNITO_USER_POOL_ID',
         'identity_pool_id': 'NZSHM22_TOSHI_COGNITO_IDENTITY_POOL_ID',
     }
-    config = {k: os.getenv(env, '') for k, env in _ENV_KEYS.items()}
+    config = {k: os.getenv(env, '') for k, env in env_keys.items()}
 
     # Always read the file so that all keys are picked up regardless of
     # which env vars are set.
     file_config = _load_config_file() or {}
-    for key in _ENV_KEYS:
+    for key in env_keys:
         if not config[key] and file_config.get(key):
             config[key] = file_config[key]
 

--- a/nshm_toshi_client/config.py
+++ b/nshm_toshi_client/config.py
@@ -71,31 +71,41 @@ def load_cognito_config() -> dict:
 
     Env vars take precedence over the file on a per-key basis: if the env var
     is set, it wins; if not, the corresponding key from the JSON file is used.
+    The file is always consulted so that keys with no env-var equivalent
+    (currently ``identity_pool_id``) are never silently dropped when all other
+    env vars are present.
+
+    Supported env vars:
+    - ``NZSHM22_TOSHI_COGNITO_DOMAIN``
+    - ``NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID``
+    - ``NZSHM22_TOSHI_COGNITO_REGION``
+    - ``NZSHM22_TOSHI_COGNITO_USER_POOL_ID``
+    - ``NZSHM22_TOSHI_COGNITO_IDENTITY_POOL_ID``
 
     Used by both `toshi-auth` (CLI) and `ToshiClientBase` (runtime) so a
     scientist who set up `~/.toshi/auth_config.json` does not also have to
     export the matching env vars.
 
     Returns a dict with keys: cognito_domain, scientist_client_id, region,
-    user_pool_id. May also include `identity_pool_id` if present in the file
-    (needed by `toshi-auth aws-creds`). Missing values are empty strings,
-    except region which defaults to 'ap-southeast-2'.
+    user_pool_id, identity_pool_id. Missing values are empty strings, except
+    region which defaults to 'ap-southeast-2'.
     """
-    config = {
-        'cognito_domain': os.getenv('NZSHM22_TOSHI_COGNITO_DOMAIN', ''),
-        'scientist_client_id': os.getenv('NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID', ''),
-        'region': os.getenv('NZSHM22_TOSHI_COGNITO_REGION', ''),
-        'user_pool_id': os.getenv('NZSHM22_TOSHI_COGNITO_USER_POOL_ID', ''),
+    _ENV_KEYS = {
+        'cognito_domain': 'NZSHM22_TOSHI_COGNITO_DOMAIN',
+        'scientist_client_id': 'NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID',
+        'region': 'NZSHM22_TOSHI_COGNITO_REGION',
+        'user_pool_id': 'NZSHM22_TOSHI_COGNITO_USER_POOL_ID',
+        'identity_pool_id': 'NZSHM22_TOSHI_COGNITO_IDENTITY_POOL_ID',
     }
+    config = {k: os.getenv(env, '') for k, env in _ENV_KEYS.items()}
 
-    if not all(config[k] for k in ('cognito_domain', 'scientist_client_id', 'region', 'user_pool_id')):
-        file_config = _load_config_file()
-        if file_config:
-            for key in ('cognito_domain', 'scientist_client_id', 'region', 'user_pool_id'):
-                if not config[key] and file_config.get(key):
-                    config[key] = file_config[key]
-            if file_config.get('identity_pool_id'):
-                config['identity_pool_id'] = file_config['identity_pool_id']
+    # Always read the file so that keys with no env-var equivalent
+    # (e.g. identity_pool_id) are picked up regardless of which env vars
+    # are set.
+    file_config = _load_config_file() or {}
+    for key in _ENV_KEYS:
+        if not config[key] and file_config.get(key):
+            config[key] = file_config[key]
 
     if not config['region']:
         config['region'] = 'ap-southeast-2'

--- a/nshm_toshi_client/config.py
+++ b/nshm_toshi_client/config.py
@@ -71,9 +71,6 @@ def load_cognito_config() -> dict:
 
     Env vars take precedence over the file on a per-key basis: if the env var
     is set, it wins; if not, the corresponding key from the JSON file is used.
-    The file is always consulted so that keys with no env-var equivalent
-    (currently ``identity_pool_id``) are never silently dropped when all other
-    env vars are present.
 
     Supported env vars:
     - ``NZSHM22_TOSHI_COGNITO_DOMAIN``
@@ -99,9 +96,8 @@ def load_cognito_config() -> dict:
     }
     config = {k: os.getenv(env, '') for k, env in _ENV_KEYS.items()}
 
-    # Always read the file so that keys with no env-var equivalent
-    # (e.g. identity_pool_id) are picked up regardless of which env vars
-    # are set.
+    # Always read the file so that all keys are picked up regardless of
+    # which env vars are set.
     file_config = _load_config_file() or {}
     for key in _ENV_KEYS:
         if not config[key] and file_config.get(key):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,17 @@ class TestLoadAuthConfig(unittest.TestCase):
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump(FAKE_CONFIG, f)
             f.flush()
-            with patch.dict('os.environ', {'TOSHI_COGNITO_CONFIG': f.name}):
+            # Clear any NZSHM22_TOSHI_COGNITO_* env vars that might bleed in from
+            # the developer's environment and override the file values.
+            clean_env = {
+                'TOSHI_COGNITO_CONFIG': f.name,
+                'NZSHM22_TOSHI_COGNITO_DOMAIN': '',
+                'NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID': '',
+                'NZSHM22_TOSHI_COGNITO_REGION': '',
+                'NZSHM22_TOSHI_COGNITO_USER_POOL_ID': '',
+                'NZSHM22_TOSHI_COGNITO_IDENTITY_POOL_ID': '',
+            }
+            with patch.dict('os.environ', clean_env):
                 config = load_auth_config()
         self.assertEqual(config['region'], 'ap-southeast-2')
         self.assertEqual(config['scientist_client_id'], 'scientist_id')
@@ -43,7 +53,17 @@ class TestLoadAuthConfig(unittest.TestCase):
             default.parent.mkdir(parents=True, exist_ok=True)
             default.write_text(json.dumps(FAKE_CONFIG))
 
-            with patch.dict('os.environ', {'TOSHI_COGNITO_CONFIG': str(default)}):
+            # Clear any NZSHM22_TOSHI_COGNITO_* env vars that might bleed in from
+            # the developer's environment and override the file values.
+            clean_env = {
+                'TOSHI_COGNITO_CONFIG': str(default),
+                'NZSHM22_TOSHI_COGNITO_DOMAIN': '',
+                'NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID': '',
+                'NZSHM22_TOSHI_COGNITO_REGION': '',
+                'NZSHM22_TOSHI_COGNITO_USER_POOL_ID': '',
+                'NZSHM22_TOSHI_COGNITO_IDENTITY_POOL_ID': '',
+            }
+            with patch.dict('os.environ', clean_env):
                 import nshm_toshi_client.cli as cli_mod
 
                 config = cli_mod.load_auth_config()
@@ -150,6 +170,64 @@ class TestLoadAuthConfig(unittest.TestCase):
         self.assertEqual(config['scientist_client_id'], 'file_scientist_id')
         self.assertEqual(config['region'], 'us-west-2')
         self.assertEqual(config['user_pool_id'], 'file_pool')
+
+    def test_identity_pool_id_from_file_when_all_env_vars_set(self):
+        """identity_pool_id must be read from the file even when all four COGNITO env vars are set.
+
+        Regression test for issue #48 (Bug 2): the old implementation only
+        consulted auth_config.json inside an ``if not all(...)`` guard over the
+        four env-backed keys, so identity_pool_id was silently dropped whenever
+        all four env vars were present.
+        """
+        from nshm_toshi_client.config import load_cognito_config
+
+        file_data = {
+            'cognito_domain': 'file-domain.example.com',
+            'scientist_client_id': 'file_scientist_id',
+            'region': 'ap-southeast-2',
+            'user_pool_id': 'ap-southeast-2_POOL',
+            'identity_pool_id': 'ap-southeast-2:fake-pool-id',
+        }
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(file_data, f)
+            f.flush()
+            env = {
+                'TOSHI_COGNITO_CONFIG': f.name,
+                # All four env vars fully populated — this triggered the bug
+                'NZSHM22_TOSHI_COGNITO_DOMAIN': 'https://env-domain.example.com',
+                'NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID': 'env_scientist_id',
+                'NZSHM22_TOSHI_COGNITO_REGION': 'ap-southeast-2',
+                'NZSHM22_TOSHI_COGNITO_USER_POOL_ID': 'ap-southeast-2_POOL',
+                'NZSHM22_TOSHI_COGNITO_IDENTITY_POOL_ID': '',  # not set via env
+            }
+            with patch.dict('os.environ', env):
+                config = load_cognito_config()
+
+        # identity_pool_id must be picked up from the file
+        self.assertEqual(config['identity_pool_id'], 'ap-southeast-2:fake-pool-id')
+        # env vars still win for the four env-backed keys
+        self.assertEqual(config['cognito_domain'], 'https://env-domain.example.com')
+        self.assertEqual(config['scientist_client_id'], 'env_scientist_id')
+
+    def test_identity_pool_id_from_env_var(self):
+        """NZSHM22_TOSHI_COGNITO_IDENTITY_POOL_ID env var is honoured."""
+        from nshm_toshi_client.config import load_cognito_config
+
+        env = {
+            'TOSHI_COGNITO_CONFIG': '',
+            'NZSHM22_TOSHI_COGNITO_DOMAIN': 'https://env-domain.example.com',
+            'NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID': 'env_scientist_id',
+            'NZSHM22_TOSHI_COGNITO_REGION': 'ap-southeast-2',
+            'NZSHM22_TOSHI_COGNITO_USER_POOL_ID': 'ap-southeast-2_POOL',
+            'NZSHM22_TOSHI_COGNITO_IDENTITY_POOL_ID': 'ap-southeast-2:env-pool-id',
+        }
+        with (
+            patch.dict('os.environ', env),
+            patch('nshm_toshi_client.config._load_config_file', return_value=None),
+        ):
+            config = load_cognito_config()
+
+        self.assertEqual(config['identity_pool_id'], 'ap-southeast-2:env-pool-id')
 
 
 # ---------------------------------------------------------------------------
@@ -527,8 +605,9 @@ class TestAwsCredsCommand(unittest.TestCase):
         self.assertIn("Not logged in", result.output)
 
     def test_aws_creds_expired_no_refresh(self):
-        expired_token = _make_jwt({"exp": time.time() - 100})
-        creds = {"access_token": expired_token}
+        expired_id_token = _make_jwt({"exp": time.time() - 100})
+        # id_token is present but expired, and no refresh_token — should error
+        creds = {"access_token": "some-access-token", "id_token": expired_id_token}
 
         with (
             patch('nshm_toshi_client.cli.load_auth_config', return_value=FAKE_CONFIG),
@@ -541,8 +620,8 @@ class TestAwsCredsCommand(unittest.TestCase):
         self.assertIn("no refresh token", result.output)
 
     def test_aws_creds_calls_get_aws_credentials(self):
-        valid_token = _make_jwt({"exp": time.time() + 3600})
-        creds = {"access_token": valid_token, "refresh_token": "refresh_tok"}
+        valid_id_token = _make_jwt({"exp": time.time() + 3600})
+        creds = {"access_token": "some-access-token", "id_token": valid_id_token, "refresh_token": "refresh_tok"}
 
         with (
             patch('nshm_toshi_client.cli.load_auth_config', return_value=FAKE_CONFIG),
@@ -553,7 +632,7 @@ class TestAwsCredsCommand(unittest.TestCase):
             result = runner.invoke(cli, ['aws-creds', '--profile', 'myprofile'])
 
         self.assertEqual(result.exit_code, 0)
-        mock_get_aws.assert_called_once_with(FAKE_CONFIG, valid_token, 'myprofile')
+        mock_get_aws.assert_called_once_with(FAKE_CONFIG, valid_id_token, 'myprofile')
         self.assertIn("AWS credentials saved", result.output)
 
     def test_get_aws_credentials_happy_path(self):
@@ -581,7 +660,7 @@ class TestAwsCredsCommand(unittest.TestCase):
                 patch.dict('sys.modules', {'boto3': mock_boto3}),
                 patch('nshm_toshi_client.cli.Path.home', return_value=Path(tmpdir)),
             ):
-                profile = get_aws_credentials(config, 'fake-access-token', profile='toshi')
+                profile = get_aws_credentials(config, 'fake-id-token', profile='toshi')
 
             self.assertEqual(profile, 'toshi')
             written = (Path(tmpdir) / '.aws' / 'credentials').read_text()
@@ -591,22 +670,29 @@ class TestAwsCredsCommand(unittest.TestCase):
             self.assertIn('aws_session_token = session', written)
 
     def test_aws_creds_refreshes_expired_token(self):
-        expired_token = _make_jwt({"exp": time.time() - 100})
-        new_token = _make_jwt({"exp": time.time() + 3600})
-        creds = {"access_token": expired_token, "refresh_token": "refresh_tok"}
+        expired_id_token = _make_jwt({"exp": time.time() - 100})
+        new_access_token = _make_jwt({"exp": time.time() + 3600})
+        new_id_token = _make_jwt({"exp": time.time() + 3600, "aud": "scientist_id"})
+        creds = {"access_token": "old-access", "id_token": expired_id_token, "refresh_token": "refresh_tok"}
 
         with (
             patch('nshm_toshi_client.cli.load_auth_config', return_value=FAKE_CONFIG),
             patch('nshm_toshi_client.cli.load_credentials', return_value=creds),
-            patch('nshm_toshi_client.cli.refresh_token', return_value={'access_token': new_token, 'expires_in': 3600}),
-            patch('nshm_toshi_client.cli.save_credentials'),
+            patch(
+                'nshm_toshi_client.cli.refresh_token',
+                return_value={'access_token': new_access_token, 'id_token': new_id_token, 'expires_in': 3600},
+            ),
+            patch('nshm_toshi_client.cli.save_credentials') as mock_save,
             patch('nshm_toshi_client.cli.get_aws_credentials', return_value='toshi') as mock_get_aws,
         ):
             runner = CliRunner()
             result = runner.invoke(cli, ['aws-creds'])
 
         self.assertEqual(result.exit_code, 0)
-        mock_get_aws.assert_called_once_with(FAKE_CONFIG, new_token, 'toshi')
+        mock_get_aws.assert_called_once_with(FAKE_CONFIG, new_id_token, 'toshi')
+        saved_creds = mock_save.call_args[0][0]
+        self.assertEqual(saved_creds['id_token'], new_id_token)
+        self.assertEqual(saved_creds['access_token'], new_access_token)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
closes #48 

Two related bugs in the Cognito-federated AWS credentials flow:

1. cli.get_aws_credentials() was passing access_token into the GetId / GetCredentialsForIdentity Logins map. Cognito Identity Pools validate the aud claim, which access tokens omit (they carry client_id instead). Rename the parameter to id_token and pass it in both Logins maps. The aws_creds command now reads creds['id_token'] and persists it on refresh. The token command's refresh block also saves id_token for consistency.

2. config.load_cognito_config() only consulted ~/.toshi/auth_config.json inside an 'if not all(...)' guard over the four NZSHM22_TOSHI_COGNITO_* env-backed keys. Since identity_pool_id has no env-var equivalent, it was silently dropped whenever all four env vars were set. Hoist the file load unconditionally; all five keys now follow the same env-first, file-fallback-per-key pattern. Also adds NZSHM22_TOSHI_COGNITO_IDENTITY_POOL_ID as a fifth env var so the JSON file is no longer strictly required.

Additional: 2 pre-existing env-leak test failures fixed.