### PR TITLE
in-memory AWS session with auto-refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] - 2026-05-29
 
 ### Added
 - `nshm_toshi_client.aws`: new module exposing `get_aws_session() -> boto3.Session` — returns STS credentials via Cognito Identity Pool federation using tokens cached by `toshi-auth login`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `nshm_toshi_client.aws`: new module exposing `get_aws_session() -> boto3.Session` — returns STS credentials via Cognito Identity Pool federation using tokens cached by `toshi-auth login`. Closes #50.
+- `nshm_toshi_client.aws`: new module exposing `get_aws_session() -> boto3.Session` — returns STS credentials via Cognito Identity Pool federation using tokens cached by `toshi-auth login`.
 - `nshm_toshi_client.aws`: typed exception hierarchy (`CognitoAuthError`, `NoCredentialsError`, `RefreshFailedError`, `ConfigIncompleteError`, `IdentityPoolError`) so callers can react to specific failure modes without string-matching.
 - `ToshiCredentialAuth.get_token()` — public API returning a fresh access_token (refreshes if expired). Raises `NoCredentialsError` / `RefreshFailedError`.
 - `ToshiCredentialAuth.get_id_token()` — public API returning a fresh id_token for use with Cognito Identity Pool federation (refreshes if expired). Raises `NoCredentialsError` / `RefreshFailedError`.
-- `NZSHM22_TOSHI_COGNITO_IDENTITY_POOL_ID` env var — identity pool ID can now be supplied via env var in addition to `~/.toshi/auth_config.json`. Closes #48 (Bug 2 optional item).
+- `NZSHM22_TOSHI_COGNITO_IDENTITY_POOL_ID` env var — identity pool ID can now be supplied via env var in addition to `~/.toshi/auth_config.json`.
 
 ### Fixed
 - `toshi-auth aws-creds` was passing `access_token` to the Cognito Identity Pool `GetId`/`GetCredentialsForIdentity` `Logins` map; Identity Pools validate the `aud` claim, which access tokens omit. Now passes `id_token`. Closes #48 (Bug 1).
-- `config.load_cognito_config()` only consulted `~/.toshi/auth_config.json` when at least one of the four `NZSHM22_TOSHI_COGNITO_*` env vars was missing, causing `identity_pool_id` to be silently dropped when all four env vars were set. File is now always consulted. Closes #48 (Bug 2).
+- `config.load_cognito_config()` only consulted `~/.toshi/auth_config.json` when at least one of the four `NZSHM22_TOSHI_COGNITO_*` env vars was missing, causing `identity_pool_id` to be silently dropped when all four env vars were set. File is now always consulted.
 
 ### Fixed
 - `ToshiTokenManager` now derives the AWS region from the Secrets Manager ARN, so `AWS_DEFAULT_REGION` is no longer required in batch environments. An optional `region=` kwarg on `ToshiTokenManager` (and `_fetch_m2m_credentials`) overrides the parsed value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `toshi-auth aws-creds` was passing `access_token` to the Cognito Identity Pool `GetId`/`GetCredentialsForIdentity` `Logins` map; Identity Pools validate the `aud` claim, which access tokens omit. Now passes `id_token`. Closes #48 (Bug 1).
 - `config.load_cognito_config()` only consulted `~/.toshi/auth_config.json` when at least one of the four `NZSHM22_TOSHI_COGNITO_*` env vars was missing, causing `identity_pool_id` to be silently dropped when all four env vars were set. File is now always consulted.
-
-### Fixed
 - `ToshiTokenManager` now derives the AWS region from the Secrets Manager ARN, so `AWS_DEFAULT_REGION` is no longer required in batch environments. An optional `region=` kwarg on `ToshiTokenManager` (and `_fetch_m2m_credentials`) overrides the parsed value.
 
 ### Changed
 - `cli.get_aws_credentials()` signature changed from `(config, id_token, profile)` to `(session, profile)` — accepts a `boto3.Session` produced by `aws.get_aws_session()` and writes its credentials to `~/.aws/credentials`. `toshi-auth aws-creds` behaviour is unchanged.
+- `cli.get_aws_credentials()` passes `id_token` to `GetId` / `GetCredentialsForIdentity` Logins instead of `access_token`.
+- All Cognito keys try env first and fall back to `~/.toshi/auth_config.json` file.
 
 ## [1.2.3] - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
+
+### Added
+- `nshm_toshi_client.aws`: new module exposing `get_aws_session() -> boto3.Session` — returns STS credentials via Cognito Identity Pool federation using tokens cached by `toshi-auth login`. Closes #50.
+- `nshm_toshi_client.aws`: typed exception hierarchy (`CognitoAuthError`, `NoCredentialsError`, `RefreshFailedError`, `ConfigIncompleteError`, `IdentityPoolError`) so callers can react to specific failure modes without string-matching.
+- `ToshiCredentialAuth.get_token()` — public API returning a fresh access_token (refreshes if expired). Raises `NoCredentialsError` / `RefreshFailedError`.
+- `ToshiCredentialAuth.get_id_token()` — public API returning a fresh id_token for use with Cognito Identity Pool federation (refreshes if expired). Raises `NoCredentialsError` / `RefreshFailedError`.
+- `NZSHM22_TOSHI_COGNITO_IDENTITY_POOL_ID` env var — identity pool ID can now be supplied via env var in addition to `~/.toshi/auth_config.json`. Closes #48 (Bug 2 optional item).
+
+### Fixed
+- `toshi-auth aws-creds` was passing `access_token` to the Cognito Identity Pool `GetId`/`GetCredentialsForIdentity` `Logins` map; Identity Pools validate the `aud` claim, which access tokens omit. Now passes `id_token`. Closes #48 (Bug 1).
+- `config.load_cognito_config()` only consulted `~/.toshi/auth_config.json` when at least one of the four `NZSHM22_TOSHI_COGNITO_*` env vars was missing, causing `identity_pool_id` to be silently dropped when all four env vars were set. File is now always consulted. Closes #48 (Bug 2).
 
 ### Fixed
 - `ToshiTokenManager` now derives the AWS region from the Secrets Manager ARN, so `AWS_DEFAULT_REGION` is no longer required in batch environments. An optional `region=` kwarg on `ToshiTokenManager` (and `_fetch_m2m_credentials`) overrides the parsed value.
 
 ### Changed
-- `cli.get_aws_credentials()` passes `id_token` to `GetId` / `GetCredentialsForIdentity` Logins instead of `access_token`.
-- All Cognito keys try env first and fall back to `~/.toshi/auth_config.json` file.
-
-### Added
-- `NZSHM22_TOSHI_COGNITO_IDENTITY_POOL_ID` env var so that `~/.toshi/auth_config.json` is not required.
+- `cli.get_aws_credentials()` signature changed from `(config, id_token, profile)` to `(session, profile)` — accepts a `boto3.Session` produced by `aws.get_aws_session()` and writes its credentials to `~/.aws/credentials`. `toshi-auth aws-creds` behaviour is unchanged.
 
 ## [1.2.3] - 2026-05-22
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,11 +70,33 @@ Check LSP diagnostics after every edit; fix type errors and missing imports imme
 
 ### Auth auto-detection (in `ToshiClientBase.__init__`)
 
-Priority order:
+`ToshiClientBase` authenticates to the **Toshi GraphQL API** using JWT Bearer
+tokens.  Detection priority order:
+
 1. `NZSHM22_TOSHI_M2M_SECRET_ARN` + `COGNITO_DOMAIN` → M2M token manager
 2. `~/.toshi/credentials` + Cognito config → interactive credential auth
 3. `auth_token` kwarg → static Bearer header
 4. `headers` kwarg → passed directly
+
+### AWS service access (`nshm_toshi_client.aws`)
+
+For AWS service calls (S3, Batch, SSM, …) use `get_aws_session()` — separate
+code path from `ToshiClientBase`:
+
+```python
+from nshm_toshi_client.aws import get_aws_session, CognitoAuthError
+
+session = get_aws_session()          # boto3.Session with STS creds
+session.client('s3').list_buckets()
+```
+
+- Returns a `boto3.Session` via Cognito Identity Pool federation using the
+  `id_token` from `~/.toshi/credentials`.  Refreshes automatically if expired.
+- Typed exception hierarchy: `CognitoAuthError` → `NoCredentialsError`,
+  `RefreshFailedError`, `ConfigIncompleteError`, `IdentityPoolError`.
+- `~/.aws/credentials` is a **sink** written by `toshi-auth aws-creds` for the
+  `aws` CLI / boto3 default credential chain.  `ToshiClientBase` never reads it;
+  in-process Python callers should use `get_aws_session()` directly.
 
 ### GraphQL call pattern
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -176,6 +176,67 @@ and **App clients** → Allowed custom scopes (grants scopes per client).
 
 ---
 
+## AWS credentials (Identity Pool federation)
+
+`toshi-auth login` writes JWT tokens to `~/.toshi/credentials`.  The same
+login produces **two distinct credential types** depending on how you consume
+them:
+
+| Path | Credential type | Stored where | Consumer |
+|---|---|---|---|
+| `ToshiClientBase` (auto-detected) | JWT Bearer token (`access_token`) | `~/.toshi/credentials` | `Authorization: Bearer` header on GraphQL calls to the Toshi API |
+| `get_aws_session()` (programmatic) | AWS STS credentials (in-memory `boto3.Session`) | not persisted | direct AWS service calls in Python (S3, Batch, …) |
+| `toshi-auth aws-creds` (CLI) | AWS STS credentials | `~/.aws/credentials` (`[toshi]` profile) | `aws` CLI / boto3 default credential chain |
+
+`ToshiClientBase` **never** reads `~/.aws/credentials` — it uses only the JWT
+path above.
+
+### In-process Python: `get_aws_session()`
+
+When you need to call AWS services from Python directly, use
+`nshm_toshi_client.aws.get_aws_session()`.  It exchanges the `id_token` from
+`~/.toshi/credentials` for STS credentials via Cognito Identity Pool federation
+and returns a ready-to-use `boto3.Session`:
+
+```python
+from nshm_toshi_client.aws import get_aws_session, CognitoAuthError
+
+try:
+    session = get_aws_session()
+    s3 = session.client('s3')
+    print(s3.list_buckets())
+except CognitoAuthError as exc:
+    # Not logged in, token refresh failed, config incomplete, etc.
+    raise SystemExit(f"Run: toshi-auth login  ({exc})") from exc
+```
+
+Typed exceptions (`NoCredentialsError`, `RefreshFailedError`,
+`ConfigIncompleteError`, `IdentityPoolError`) all inherit from
+`CognitoAuthError`, so you can catch the base or react to specific failures.
+
+### Out-of-process tools: `toshi-auth aws-creds`
+
+For the `aws` CLI, scripts that rely on `AWS_PROFILE`, or any tool that uses
+the boto3 default credential chain, write the STS credentials to
+`~/.aws/credentials` once and let those tools pick them up:
+
+```bash
+toshi-auth aws-creds --profile toshi
+# → writes [toshi] section to ~/.aws/credentials
+
+aws --profile toshi s3 ls
+AWS_PROFILE=toshi python my_script.py
+```
+
+### When to use which
+
+Use `get_aws_session()` when your Python process needs AWS access — no file
+round-trip, typed exceptions, and token refresh handled automatically.  Use
+`toshi-auth aws-creds` when you need credentials available to the `aws` CLI or
+other tools outside your Python process.
+
+---
+
 ## toshi-auth CLI
 
 Install with `pip install nshm-toshi-client[cli]`.
@@ -189,7 +250,7 @@ env var pointing to a config file, or falls back to `NZSHM22_TOSHI_COGNITO_*` en
 | `toshi-auth logout` | Delete saved credentials at `~/.toshi/credentials` |
 | `toshi-auth token [--raw]` | Print current Bearer token, auto-refreshing if expired |
 | `toshi-auth whoami` | Decode and display JWT claims (user, scopes, expiry) |
-| `toshi-auth aws-creds [--profile]` | Exchange Cognito token for AWS STS credentials |
+| `toshi-auth aws-creds [--profile]` | Exchange Cognito token for AWS STS credentials, written to `~/.aws/credentials` |
 
 ## Methods
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,20 +2,17 @@
 
 ## Authentication
 
-There are three ways to authenticate with the Toshi API, listed in priority order.
-`ToshiClientBase` auto-detects the method based on what is configured:
+There are three ways to authenticate with the Toshi API, listed in priority order. `ToshiClientBase` auto-detects the method based on what is configured:
 
 1. M2M — used when `NZSHM22_TOSHI_M2M_SECRET_ARN` and `NZSHM22_TOSHI_COGNITO_DOMAIN` are both set.
 2. Interactive scientist — used when `~/.toshi/credentials` exists and the Cognito domain + scientist client ID are configured (via `~/.toshi/auth_config.json` or the matching `NZSHM22_TOSHI_COGNITO_*` env vars).
 3. Legacy API key — **not auto-detected**; you must pass `headers={"x-api-key": ...}` explicitly.
 
-If both M2M env vars and `~/.toshi/credentials` are present on the same machine, M2M wins.
-`ToshiClientBase` logs a warning when auto-detection overrides an explicit `auth_token` or `headers` argument.
+If both M2M env vars and `~/.toshi/credentials` are present on the same machine, M2M wins. `ToshiClientBase` logs a warning when auto-detection overrides an explicit `auth_token` or `headers` argument.
 
 ### 1. M2M (machine-to-machine) — for automation and batch jobs
 
-M2M credentials live in AWS Secrets Manager and are fetched at process start
-using the runtime's IAM role. The secret value must be JSON:
+M2M credentials live in AWS Secrets Manager and are fetched at process start using the runtime's IAM role. The secret value must be JSON:
 
 ```json
 {
@@ -45,10 +42,7 @@ api = ToshiFile(
 file = api.get_file("{example_id}")
 ```
 
-The Secrets Manager fetch happens once when `ToshiTokenManager` is constructed
-(either explicitly, or implicitly by `ToshiClientBase` when auto-detecting);
-Cognito access tokens are refreshed transparently from there. Long-running
-jobs (24h+) never need to manage token lifetime.
+The Secrets Manager fetch happens once when `ToshiTokenManager` is constructed (either explicitly, or implicitly by `ToshiClientBase` when auto-detecting); Cognito access tokens are refreshed transparently from there. Long-running jobs (24h+) never need to manage token lifetime.
 
 You can also pass a `ToshiTokenManager` explicitly:
 
@@ -76,10 +70,7 @@ Install the CLI:
 pip install nshm-toshi-client[cli]
 ```
 
-Then give the CLI the Cognito pool details. The simplest way is a JSON config file —
-copy [`docs/auth_config.example.json`](auth_config.example.json) to
-`~/.toshi/auth_config.json` and fill in the values for your Toshi deployment (ask
-the Toshi admin if you don't have them):
+Then give the CLI the Cognito pool details. The simplest way is a JSON config file — copy [`docs/auth_config.example.json`](auth_config.example.json) to `~/.toshi/auth_config.json` and fill in the values for your Toshi deployment (ask the Toshi admin if you don't have them):
 
 ```bash
 mkdir -p ~/.toshi
@@ -93,9 +84,7 @@ Log in (you'll be prompted for email + password):
 toshi-auth login
 ```
 
-This saves tokens to `~/.toshi/credentials`. Both `toshi-auth` and
-`ToshiClientBase` read the same `~/.toshi/auth_config.json`, so no extra
-env vars are needed for Cognito auth. You still need the API URL:
+This saves tokens to `~/.toshi/credentials`. Both `toshi-auth` and `ToshiClientBase` read the same `~/.toshi/auth_config.json`, so no extra env vars are needed for Cognito auth. You still need the API URL:
 
 ```bash
 export NZSHM22_TOSHI_API_URL=https://example-api-url.com/graphql
@@ -113,11 +102,7 @@ api = ToshiFile(
 file = api.get_file("{example_id}")
 ```
 
-> **Alternative:** instead of `~/.toshi/auth_config.json`, you can set the
-> `NZSHM22_TOSHI_COGNITO_*` env vars (domain, scientist client ID, region,
-> user pool ID). Env vars take precedence over the file on a per-key basis,
-> so you can mix the two (e.g. file for shared defaults, env to override
-> `NZSHM22_TOSHI_COGNITO_DOMAIN` in a dev pool).
+> **Alternative:** instead of `~/.toshi/auth_config.json`, you can set the `NZSHM22_TOSHI_COGNITO_*` env vars (domain, scientist client ID, region, user pool ID). Env vars take precedence over the file on a per-key basis, so you can mix the two (e.g. file for shared defaults, env to override `NZSHM22_TOSHI_COGNITO_DOMAIN` in a dev pool).
 
 ### 3. API key (legacy)
 
@@ -141,10 +126,7 @@ The helper function `get_auth_kwargs()` returns the correct constructor keyword 
 
 ## Scopes
 
-Toshi API authorisation is gated by OAuth scopes defined as a **Resource
-Server** in the Cognito user pool. The naming convention is
-`{resource_server}/{scope}` — e.g. `toshi/read`, `toshi/write`. Scopes
-themselves are deployment configuration; this client only *requests* them.
+Toshi API authorisation is gated by OAuth scopes defined as a **Resource Server** in the Cognito user pool. The naming convention is `{resource_server}/{scope}` — e.g. `toshi/read`, `toshi/write`. Scopes themselves are deployment configuration; this client only *requests* them.
 
 You can see what scopes the token you currently hold actually has:
 
@@ -170,17 +152,13 @@ When verifying scope policy against a deployment:
 - An M2M token request will fail at Cognito (not the API) if the automation app client isn't permitted the hardcoded scopes — look for `invalid_scope` in the Cognito response.
 - Scientist scope changes don't require a code release — but a user already holding a token must `toshi-auth logout && toshi-auth login` to pick up the new scopes.
 
-To find the authoritative scope definition: AWS Console → Cognito → your
-user pool → App integration → **Resource servers** (defines available scopes)
-and **App clients** → Allowed custom scopes (grants scopes per client).
+To find the authoritative scope definition: AWS Console → Cognito → your user pool → App integration → **Resource servers** (defines available scopes) and **App clients** → Allowed custom scopes (grants scopes per client).
 
 ---
 
 ## AWS credentials (Identity Pool federation)
 
-`toshi-auth login` writes JWT tokens to `~/.toshi/credentials`.  The same
-login produces **two distinct credential types** depending on how you consume
-them:
+`toshi-auth login` writes JWT tokens to `~/.toshi/credentials`. The same login produces **two distinct credential types** depending on how you consume them:
 
 | Path | Credential type | Stored where | Consumer |
 |---|---|---|---|
@@ -188,15 +166,11 @@ them:
 | `get_aws_session()` (programmatic) | AWS STS credentials (in-memory `boto3.Session`) | not persisted | direct AWS service calls in Python (S3, Batch, …) |
 | `toshi-auth aws-creds` (CLI) | AWS STS credentials | `~/.aws/credentials` (`[toshi]` profile) | `aws` CLI / boto3 default credential chain |
 
-`ToshiClientBase` **never** reads `~/.aws/credentials` — it uses only the JWT
-path above.
+`ToshiClientBase` **never** reads `~/.aws/credentials` — it uses only the JWT path above.
 
 ### In-process Python: `get_aws_session()`
 
-When you need to call AWS services from Python directly, use
-`nshm_toshi_client.aws.get_aws_session()`.  It exchanges the `id_token` from
-`~/.toshi/credentials` for STS credentials via Cognito Identity Pool federation
-and returns a ready-to-use `boto3.Session`:
+When you need to call AWS services from Python directly, use `nshm_toshi_client.aws.get_aws_session()`. It exchanges the `id_token` from `~/.toshi/credentials` for STS credentials via Cognito Identity Pool federation and returns a ready-to-use `boto3.Session`:
 
 ```python
 from nshm_toshi_client.aws import get_aws_session, CognitoAuthError
@@ -210,15 +184,11 @@ except CognitoAuthError as exc:
     raise SystemExit(f"Run: toshi-auth login  ({exc})") from exc
 ```
 
-Typed exceptions (`NoCredentialsError`, `RefreshFailedError`,
-`ConfigIncompleteError`, `IdentityPoolError`) all inherit from
-`CognitoAuthError`, so you can catch the base or react to specific failures.
+Typed exceptions (`NoCredentialsError`, `RefreshFailedError`, `ConfigIncompleteError`, `IdentityPoolError`) all inherit from `CognitoAuthError`, so you can catch the base or react to specific failures.
 
 ### Out-of-process tools: `toshi-auth aws-creds`
 
-For the `aws` CLI, scripts that rely on `AWS_PROFILE`, or any tool that uses
-the boto3 default credential chain, write the STS credentials to
-`~/.aws/credentials` once and let those tools pick them up:
+For the `aws` CLI, scripts that rely on `AWS_PROFILE`, or any tool that uses the boto3 default credential chain, write the STS credentials to `~/.aws/credentials` once and let those tools pick them up:
 
 ```bash
 toshi-auth aws-creds --profile toshi
@@ -230,10 +200,7 @@ AWS_PROFILE=toshi python my_script.py
 
 ### When to use which
 
-Use `get_aws_session()` when your Python process needs AWS access — no file
-round-trip, typed exceptions, and token refresh handled automatically.  Use
-`toshi-auth aws-creds` when you need credentials available to the `aws` CLI or
-other tools outside your Python process.
+Use `get_aws_session()` when your Python process needs AWS access — no file round-trip, typed exceptions, and token refresh handled automatically. Use `toshi-auth aws-creds` when you need credentials available to the `aws` CLI or other tools outside your Python process.
 
 ---
 
@@ -241,8 +208,7 @@ other tools outside your Python process.
 
 Install with `pip install nshm-toshi-client[cli]`.
 
-The CLI reads config from `~/.toshi/auth_config.json`, or `TOSHI_COGNITO_CONFIG`
-env var pointing to a config file, or falls back to `NZSHM22_TOSHI_COGNITO_*` env vars.
+The CLI reads config from `~/.toshi/auth_config.json`, or `TOSHI_COGNITO_CONFIG` env var pointing to a config file, or falls back to `NZSHM22_TOSHI_COGNITO_*` env vars.
 
 | Command | Description |
 |---------|-------------|

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,10 +21,7 @@ M2M credentials live in AWS Secrets Manager and are fetched at process start usi
 }
 ```
 
-Grant your runtime IAM role `secretsmanager:GetSecretValue` on the secret ARN,
-then set these env vars and the client configures itself automatically. The AWS
-region is derived automatically from the secret ARN, so `AWS_DEFAULT_REGION`
-does not need to be set for the M2M path.
+Grant your runtime IAM role `secretsmanager:GetSecretValue` on the secret ARN, then set these env vars and the client configures itself automatically. The AWS region is derived automatically from the secret ARN, so `AWS_DEFAULT_REGION` does not need to be set for the M2M path.
 
 ```bash
 export NZSHM22_TOSHI_API_URL=https://example-api-url.com/graphql

--- a/nshm_toshi_client/auth.py
+++ b/nshm_toshi_client/auth.py
@@ -187,7 +187,7 @@ class ToshiCredentialAuth(AuthBase):
         self._lock = threading.Lock()
 
     def __call__(self, r):
-        r.headers["Authorization"] = f"Bearer {self._get_token()}"
+        r.headers["Authorization"] = f"Bearer {self.get_token()}"
         return r
 
     # ------------------------------------------------------------------
@@ -225,10 +225,6 @@ class ToshiCredentialAuth(AuthBase):
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
-
-    def _get_token(self) -> str:
-        # Private — use get_token() or nshm_toshi_client.aws.get_aws_session() instead.
-        return self.get_token()
 
     def _get_valid_credentials(self) -> dict:
         """Load credentials, refresh if access_token is expired, return the dict."""

--- a/nshm_toshi_client/auth.py
+++ b/nshm_toshi_client/auth.py
@@ -190,21 +190,66 @@ class ToshiCredentialAuth(AuthBase):
         r.headers["Authorization"] = f"Bearer {self._get_token()}"
         return r
 
+    # ------------------------------------------------------------------
+    # Public token API
+    # ------------------------------------------------------------------
+
+    def get_token(self) -> str:
+        """Return a fresh access_token, refreshing if expired.
+
+        Raises:
+            nshm_toshi_client.aws.NoCredentialsError: credentials missing/empty.
+            nshm_toshi_client.aws.RefreshFailedError: refresh token rejected.
+        """
+        return self._get_valid_credentials()['access_token']
+
+    def get_id_token(self) -> str:
+        """Return a fresh id_token, refreshing if expired.
+
+        The id_token (not the access_token) is required by Cognito Identity
+        Pools; use this method when exchanging tokens for AWS STS credentials.
+
+        Raises:
+            nshm_toshi_client.aws.NoCredentialsError: credentials missing, empty,
+                or id_token absent (re-run ``toshi-auth login`` to re-persist it).
+            nshm_toshi_client.aws.RefreshFailedError: refresh token rejected.
+        """
+        creds = self._get_valid_credentials()
+        id_token = creds.get('id_token', '')
+        if not id_token:
+            from nshm_toshi_client.aws import NoCredentialsError
+
+            raise NoCredentialsError("No id_token in credentials. Re-run: toshi-auth login")
+        return id_token
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
     def _get_token(self) -> str:
+        # Private — use get_token() or nshm_toshi_client.aws.get_aws_session() instead.
+        return self.get_token()
+
+    def _get_valid_credentials(self) -> dict:
+        """Load credentials, refresh if access_token is expired, return the dict."""
+        from nshm_toshi_client.aws import NoCredentialsError, RefreshFailedError
+
         with self._lock:
             creds = load_credentials()
             access_token = creds.get('access_token', '')
             if not access_token:
-                raise RuntimeError("No credentials found. Run: toshi-auth login")
+                raise NoCredentialsError("No credentials found. Run: toshi-auth login")
             if is_token_expired(access_token):
                 refresh_tok = creds.get('refresh_token', '')
                 if not refresh_tok:
-                    raise RuntimeError("Token expired and no refresh token. Run: toshi-auth login")
+                    raise RefreshFailedError("Token expired and no refresh token. Run: toshi-auth login")
                 logger.debug("ToshiCredentialAuth: refreshing expired token")
-                creds = self._refresh(refresh_tok, creds)
+                try:
+                    creds = self._refresh(refresh_tok, creds)
+                except Exception as exc:
+                    raise RefreshFailedError(f"Token refresh failed: {exc}") from exc
                 save_credentials(creds)
-                access_token = creds['access_token']
-            return access_token
+            return creds
 
     def _refresh(self, refresh_tok: str, creds: dict) -> dict:
         body = parse.urlencode(

--- a/nshm_toshi_client/auth.py
+++ b/nshm_toshi_client/auth.py
@@ -15,6 +15,42 @@ CREDENTIALS_PATH = Path.home() / '.toshi' / 'credentials'
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Typed exception hierarchy (re-exported by nshm_toshi_client.aws)
+# ---------------------------------------------------------------------------
+
+
+class CognitoAuthError(Exception):
+    """Base class for all Cognito-federation failures."""
+
+
+class NoCredentialsError(CognitoAuthError):
+    """~/.toshi/credentials is missing or lacks the required token; re-authenticate."""
+
+
+class RefreshFailedError(CognitoAuthError):
+    """Refresh token expired or was rejected by Cognito; re-authenticate."""
+
+
+class ConfigIncompleteError(CognitoAuthError):
+    """auth_config / env vars are missing one or more required keys.
+
+    Attributes:
+        missing: list of key names that were absent or empty.
+    """
+
+    def __init__(self, missing: list[str]) -> None:
+        super().__init__(f"Cognito config missing required keys: {', '.join(missing)}")
+        self.missing = missing
+
+
+class IdentityPoolError(CognitoAuthError):
+    """Cognito Identity Pool rejected the federation request (wraps botocore ClientError)."""
+
+
+# ---------------------------------------------------------------------------
+
+
 def _region_from_arn(secret_arn: str) -> str:
     """Extract the AWS region from a Secrets Manager ARN.
 
@@ -217,9 +253,7 @@ class ToshiCredentialAuth(AuthBase):
         creds = self._get_valid_credentials()
         id_token = creds.get('id_token', '')
         if not id_token:
-            from nshm_toshi_client.aws import NoCredentialsError
-
-            raise NoCredentialsError("No id_token in credentials. Re-run: toshi-auth login")
+            raise NoCredentialsError("No id_token in credentials; re-authenticate to obtain a fresh one.")
         return id_token
 
     # ------------------------------------------------------------------
@@ -228,17 +262,15 @@ class ToshiCredentialAuth(AuthBase):
 
     def _get_valid_credentials(self) -> dict:
         """Load credentials, refresh if access_token is expired, return the dict."""
-        from nshm_toshi_client.aws import NoCredentialsError, RefreshFailedError
-
         with self._lock:
             creds = load_credentials()
             access_token = creds.get('access_token', '')
             if not access_token:
-                raise NoCredentialsError("No credentials found. Run: toshi-auth login")
+                raise NoCredentialsError("No credentials found; re-authenticate.")
             if is_token_expired(access_token):
                 refresh_tok = creds.get('refresh_token', '')
                 if not refresh_tok:
-                    raise RefreshFailedError("Token expired and no refresh token. Run: toshi-auth login")
+                    raise RefreshFailedError("Token expired and no refresh token available; re-authenticate.")
                 logger.debug("ToshiCredentialAuth: refreshing expired token")
                 try:
                     creds = self._refresh(refresh_tok, creds)

--- a/nshm_toshi_client/aws.py
+++ b/nshm_toshi_client/aws.py
@@ -1,0 +1,117 @@
+"""Programmatic AWS-credentials helper for Cognito Identity Pool federation.
+
+Typical usage::
+
+    from nshm_toshi_client.aws import get_aws_session, CognitoAuthError
+
+    try:
+        session = get_aws_session()
+        s3 = session.client('s3')
+    except CognitoAuthError as exc:
+        # Not logged in, refresh failed, config incomplete, etc.
+        raise SystemExit(f"toshi-auth login required: {exc}") from exc
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import boto3
+
+
+# ---------------------------------------------------------------------------
+# Typed exception hierarchy
+# ---------------------------------------------------------------------------
+
+
+class CognitoAuthError(Exception):
+    """Base class for all Cognito-federation failures raised by get_aws_session()."""
+
+
+class NoCredentialsError(CognitoAuthError):
+    """~/.toshi/credentials is missing or lacks id_token. Run: toshi-auth login."""
+
+
+class RefreshFailedError(CognitoAuthError):
+    """Refresh token expired or rejected by Cognito. Run: toshi-auth login."""
+
+
+class ConfigIncompleteError(CognitoAuthError):
+    """auth_config / env vars are missing one or more required keys.
+
+    Attributes:
+        missing: list of key names that were absent or empty.
+    """
+
+    def __init__(self, missing: list[str]) -> None:
+        super().__init__(f"Cognito config missing required keys: {', '.join(missing)}")
+        self.missing = missing
+
+
+class IdentityPoolError(CognitoAuthError):
+    """Cognito Identity Pool rejected the federation request (wraps botocore ClientError)."""
+
+
+# ---------------------------------------------------------------------------
+# Required config keys
+# ---------------------------------------------------------------------------
+
+_REQUIRED_KEYS = ('scientist_client_id', 'cognito_domain', 'region', 'user_pool_id', 'identity_pool_id')
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_aws_session() -> boto3.Session:
+    """Return a boto3.Session whose credentials come from Cognito Identity Pool
+    federation, using tokens cached by ``toshi-auth login``. Refreshes if expired.
+
+    Raises:
+        NoCredentialsError: ~/.toshi/credentials is missing or lacks id_token.
+        RefreshFailedError: refresh token expired or the token endpoint rejected it.
+        ConfigIncompleteError: auth_config or env vars are missing required keys.
+        IdentityPoolError: cognito-identity GetId/GetCredentialsForIdentity rejected.
+    """
+    import boto3 as _boto3
+    import botocore.exceptions
+
+    from nshm_toshi_client.auth import ToshiCredentialAuth
+    from nshm_toshi_client.config import load_cognito_config
+
+    # 1. Resolve config and validate all required keys are present.
+    config = load_cognito_config()
+    missing = [k for k in _REQUIRED_KEYS if not config.get(k)]
+    if missing:
+        raise ConfigIncompleteError(missing)
+
+    cognito_domain = config['cognito_domain'].removeprefix('https://')
+    region = config['region']
+    user_pool_id = config['user_pool_id']
+    identity_pool_id = config['identity_pool_id']
+
+    # 2. Get a fresh id_token, refreshing if the stored token is expired.
+    #    NoCredentialsError / RefreshFailedError propagate directly.
+    auth = ToshiCredentialAuth(cognito_domain=cognito_domain, scientist_client_id=config['scientist_client_id'])
+    id_token = auth.get_id_token()
+
+    # 3. Exchange id_token for STS credentials via Cognito Identity Pool.
+    logins = {f'cognito-idp.{region}.amazonaws.com/{user_pool_id}': id_token}
+    cognito_identity = _boto3.client('cognito-identity', region_name=region)
+    try:
+        get_id_resp = cognito_identity.get_id(IdentityPoolId=identity_pool_id, Logins=logins)
+        creds_resp = cognito_identity.get_credentials_for_identity(
+            IdentityId=get_id_resp['IdentityId'], Logins=logins
+        )
+    except botocore.exceptions.ClientError as exc:
+        raise IdentityPoolError(str(exc)) from exc
+
+    aws_creds = creds_resp['Credentials']
+    return _boto3.Session(
+        aws_access_key_id=aws_creds['AccessKeyId'],
+        aws_secret_access_key=aws_creds['SecretKey'],
+        aws_session_token=aws_creds['SessionToken'],
+        region_name=region,
+    )

--- a/nshm_toshi_client/aws.py
+++ b/nshm_toshi_client/aws.py
@@ -53,13 +53,6 @@ __all__ = [
 ]
 
 # ---------------------------------------------------------------------------
-# Required config keys
-# ---------------------------------------------------------------------------
-
-_REQUIRED_KEYS = ('scientist_client_id', 'cognito_domain', 'region', 'user_pool_id', 'identity_pool_id')
-
-
-# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -78,11 +71,11 @@ def get_aws_session() -> boto3.Session:
     import botocore.exceptions
 
     from nshm_toshi_client.auth import ToshiCredentialAuth
-    from nshm_toshi_client.config import load_cognito_config
+    from nshm_toshi_client.config import COGNITO_CONFIG_KEYS, load_cognito_config
 
     # 1. Resolve config and validate all required keys are present.
     config = load_cognito_config()
-    missing = [k for k in _REQUIRED_KEYS if not config.get(k)]
+    missing = [k for k in COGNITO_CONFIG_KEYS if not config.get(k)]
     if missing:
         raise ConfigIncompleteError(missing)
 

--- a/nshm_toshi_client/aws.py
+++ b/nshm_toshi_client/aws.py
@@ -21,7 +21,7 @@ Typical usage::
         s3 = session.client('s3')
     except CognitoAuthError as exc:
         # Not logged in, refresh failed, config incomplete, etc.
-        raise SystemExit(f"toshi-auth login required: {exc}") from exc
+        raise SystemExit(f"Re-authenticate: {exc}") from exc
 """
 
 from __future__ import annotations
@@ -31,39 +31,26 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import boto3
 
-
 # ---------------------------------------------------------------------------
-# Typed exception hierarchy
+# Exception hierarchy — defined in auth.py, re-exported here for the public API
 # ---------------------------------------------------------------------------
 
+from nshm_toshi_client.auth import (  # noqa: E402
+    CognitoAuthError,
+    ConfigIncompleteError,
+    IdentityPoolError,
+    NoCredentialsError,
+    RefreshFailedError,
+)
 
-class CognitoAuthError(Exception):
-    """Base class for all Cognito-federation failures raised by get_aws_session()."""
-
-
-class NoCredentialsError(CognitoAuthError):
-    """~/.toshi/credentials is missing or lacks id_token. Run: toshi-auth login."""
-
-
-class RefreshFailedError(CognitoAuthError):
-    """Refresh token expired or rejected by Cognito. Run: toshi-auth login."""
-
-
-class ConfigIncompleteError(CognitoAuthError):
-    """auth_config / env vars are missing one or more required keys.
-
-    Attributes:
-        missing: list of key names that were absent or empty.
-    """
-
-    def __init__(self, missing: list[str]) -> None:
-        super().__init__(f"Cognito config missing required keys: {', '.join(missing)}")
-        self.missing = missing
-
-
-class IdentityPoolError(CognitoAuthError):
-    """Cognito Identity Pool rejected the federation request (wraps botocore ClientError)."""
-
+__all__ = [
+    'CognitoAuthError',
+    'NoCredentialsError',
+    'RefreshFailedError',
+    'ConfigIncompleteError',
+    'IdentityPoolError',
+    'get_aws_session',
+]
 
 # ---------------------------------------------------------------------------
 # Required config keys
@@ -99,14 +86,16 @@ def get_aws_session() -> boto3.Session:
     if missing:
         raise ConfigIncompleteError(missing)
 
-    cognito_domain = config['cognito_domain'].removeprefix('https://')
     region = config['region']
     user_pool_id = config['user_pool_id']
     identity_pool_id = config['identity_pool_id']
 
     # 2. Get a fresh id_token, refreshing if the stored token is expired.
     #    NoCredentialsError / RefreshFailedError propagate directly.
-    auth = ToshiCredentialAuth(cognito_domain=cognito_domain, scientist_client_id=config['scientist_client_id'])
+    auth = ToshiCredentialAuth(
+        cognito_domain=config['cognito_domain'],
+        scientist_client_id=config['scientist_client_id'],
+    )
     id_token = auth.get_id_token()
 
     # 3. Exchange id_token for STS credentials via Cognito Identity Pool.
@@ -114,9 +103,7 @@ def get_aws_session() -> boto3.Session:
     cognito_identity = _boto3.client('cognito-identity', region_name=region)
     try:
         get_id_resp = cognito_identity.get_id(IdentityPoolId=identity_pool_id, Logins=logins)
-        creds_resp = cognito_identity.get_credentials_for_identity(
-            IdentityId=get_id_resp['IdentityId'], Logins=logins
-        )
+        creds_resp = cognito_identity.get_credentials_for_identity(IdentityId=get_id_resp['IdentityId'], Logins=logins)
     except botocore.exceptions.ClientError as exc:
         raise IdentityPoolError(str(exc)) from exc
 

--- a/nshm_toshi_client/aws.py
+++ b/nshm_toshi_client/aws.py
@@ -1,5 +1,17 @@
 """Programmatic AWS-credentials helper for Cognito Identity Pool federation.
 
+Use this module when you need a ``boto3.Session`` for **AWS service** access
+(S3, Batch, SSM, …).  It is *not* used by ``ToshiClientBase``, which
+authenticates to the Toshi GraphQL API using a JWT Bearer token sourced from
+``~/.toshi/credentials``.
+
+``get_aws_session()`` is the in-process equivalent of ``toshi-auth aws-creds``
+(the CLI command that writes ``~/.aws/credentials``).  Both start from the same
+``id_token`` in ``~/.toshi/credentials``; the CLI persists the resulting STS
+credentials to disk for the ``aws`` CLI and boto3's default credential chain,
+while this function returns the ``boto3.Session`` directly — no file round-trip,
+typed exceptions, and token refresh handled automatically.
+
 Typical usage::
 
     from nshm_toshi_client.aws import get_aws_session, CognitoAuthError

--- a/nshm_toshi_client/cli.py
+++ b/nshm_toshi_client/cli.py
@@ -346,7 +346,12 @@ def whoami():
 @cli.command('aws-creds')
 @click.option('--profile', default='toshi', help='AWS credentials profile name', show_default=True)
 def aws_creds(profile):
-    """Exchange Cognito token for AWS STS credentials and write to ~/.aws/credentials."""
+    """Exchange Cognito token for AWS STS credentials and write to ~/.aws/credentials.
+
+    For in-process Python callers, use ``nshm_toshi_client.aws.get_aws_session()``
+    directly — this command exists for shells, the ``aws`` CLI, and tools that
+    already use the boto3 default credential chain.
+    """
     click.echo('Getting AWS credentials via Identity Pool...')
     try:
         session = get_aws_session()

--- a/nshm_toshi_client/cli.py
+++ b/nshm_toshi_client/cli.py
@@ -32,8 +32,12 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
+
+if TYPE_CHECKING:
+    import boto3
 
 from nshm_toshi_client.auth import (
     CREDENTIALS_PATH,
@@ -194,7 +198,7 @@ def refresh_token(config: dict, refresh_tok: str) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def get_aws_credentials(session: "boto3.Session", profile: str = 'toshi') -> str:  # type: ignore[name-defined]
+def get_aws_credentials(session: "boto3.Session", profile: str = 'toshi') -> str:
     """Write STS credentials from a boto3 Session to ~/.aws/credentials.
 
     The Session is produced by ``nshm_toshi_client.aws.get_aws_session()``,
@@ -355,11 +359,7 @@ def aws_creds(profile):
     click.echo('Getting AWS credentials via Identity Pool...')
     try:
         session = get_aws_session()
-    except NoCredentialsError as exc:
-        raise click.ClickException(f'{exc}') from None
-    except RefreshFailedError as exc:
-        raise click.ClickException(f'{exc}') from None
-    except ConfigIncompleteError as exc:
+    except (NoCredentialsError, RefreshFailedError, ConfigIncompleteError) as exc:
         raise click.ClickException(f'{exc}') from None
     except IdentityPoolError as exc:
         raise click.ClickException(f'Identity Pool federation failed: {exc}') from None

--- a/nshm_toshi_client/cli.py
+++ b/nshm_toshi_client/cli.py
@@ -42,6 +42,13 @@ from nshm_toshi_client.auth import (
     load_credentials,
     save_credentials,
 )
+from nshm_toshi_client.aws import (
+    ConfigIncompleteError,
+    IdentityPoolError,
+    NoCredentialsError,
+    RefreshFailedError,
+    get_aws_session,
+)
 
 try:
     from dotenv import load_dotenv
@@ -187,39 +194,18 @@ def refresh_token(config: dict, refresh_tok: str) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def get_aws_credentials(config: dict, id_token: str, profile: str = 'toshi') -> str:
-    """Exchange Cognito id_token for AWS STS credentials via Identity Pool."""
-    boto3 = _get_boto3()
+def get_aws_credentials(session: "boto3.Session", profile: str = 'toshi') -> str:  # type: ignore[name-defined]
+    """Write STS credentials from a boto3 Session to ~/.aws/credentials.
 
-    region = config['region']
-    identity_pool_id = config.get('identity_pool_id')
+    The Session is produced by ``nshm_toshi_client.aws.get_aws_session()``,
+    which handles the Cognito Identity Pool federation.  Keeping these two
+    steps separate lets non-CLI callers use the Session directly without
+    touching the credentials file.
+    """
+    frozen = session.get_credentials().get_frozen_credentials()
+    region = session.region_name
 
-    if not identity_pool_id:
-        raise click.ClickException('Identity Pool ID not found in config.')
-
-    cognito_identity = boto3.client('cognito-identity', region_name=region)
-
-    click.echo(f'Getting Identity ID from pool: {identity_pool_id} ...')
-    resp = cognito_identity.get_id(
-        IdentityPoolId=identity_pool_id,
-        Logins={
-            f'cognito-idp.{region}.amazonaws.com/{config["user_pool_id"]}': id_token,
-        },
-    )
-    identity_id = resp['IdentityId']
-    click.echo(f'  Identity ID: {identity_id}')
-
-    click.echo('Getting temporary AWS credentials ...')
-    resp = cognito_identity.get_credentials_for_identity(
-        IdentityId=identity_id,
-        Logins={
-            f'cognito-idp.{region}.amazonaws.com/{config["user_pool_id"]}': id_token,
-        },
-    )
-
-    creds = resp['Credentials']
-    click.echo(f'  AccessKeyId: {creds["AccessKeyId"]}')
-    click.echo(f'  Expires: {creds["Expiration"].astimezone(timezone.utc).isoformat()}')
+    click.echo(f'  AccessKeyId: {frozen.access_key}')
 
     aws_credentials_path = Path.home() / '.aws' / 'credentials'
     aws_credentials_path.parent.mkdir(parents=True, exist_ok=True)
@@ -234,9 +220,9 @@ def get_aws_credentials(config: dict, id_token: str, profile: str = 'toshi') -> 
 
     if profile not in parser.sections():
         parser.add_section(profile)
-    parser.set(profile, 'aws_access_key_id', creds['AccessKeyId'])
-    parser.set(profile, 'aws_secret_access_key', creds['SecretKey'])
-    parser.set(profile, 'aws_session_token', creds['SessionToken'])
+    parser.set(profile, 'aws_access_key_id', frozen.access_key)
+    parser.set(profile, 'aws_secret_access_key', frozen.secret_key)
+    parser.set(profile, 'aws_session_token', frozen.token)
     parser.set(profile, 'region', region)
 
     with open(aws_credentials_path, 'w') as f:
@@ -361,31 +347,19 @@ def whoami():
 @click.option('--profile', default='toshi', help='AWS credentials profile name', show_default=True)
 def aws_creds(profile):
     """Exchange Cognito token for AWS STS credentials and write to ~/.aws/credentials."""
-    config = load_auth_config()
-    creds = load_credentials()
+    click.echo('Getting AWS credentials via Identity Pool...')
+    try:
+        session = get_aws_session()
+    except NoCredentialsError as exc:
+        raise click.ClickException(f'{exc}') from None
+    except RefreshFailedError as exc:
+        raise click.ClickException(f'{exc}') from None
+    except ConfigIncompleteError as exc:
+        raise click.ClickException(f'{exc}') from None
+    except IdentityPoolError as exc:
+        raise click.ClickException(f'Identity Pool federation failed: {exc}') from None
 
-    id_token = creds.get('id_token', '')
-    if not id_token:
-        raise click.ClickException('Not logged in. Run: toshi-auth login')
-
-    if is_token_expired(id_token, buffer_seconds=300):
-        refresh_tok = creds.get('refresh_token', '')
-        if not refresh_tok:
-            raise click.ClickException('Token expired and no refresh token. Run: toshi-auth login')
-        click.echo('Token expired, refreshing...', err=True)
-        try:
-            token_resp = refresh_token(config, refresh_tok)
-            creds['access_token'] = token_resp['access_token']
-            id_token = token_resp.get('id_token', '')
-            creds['id_token'] = id_token
-            creds['expires_at'] = time.time() + token_resp.get('expires_in', 3600)
-            if 'refresh_token' in token_resp:
-                creds['refresh_token'] = token_resp['refresh_token']
-            save_credentials(creds)
-        except Exception as e:
-            raise click.ClickException(f'Token refresh failed: {e}. Run: toshi-auth login') from None
-
-    result_profile = get_aws_credentials(config, id_token, profile)
+    result_profile = get_aws_credentials(session, profile)
 
     click.echo(f'\nAWS credentials saved to profile [{result_profile}] in ~/.aws/credentials')
     click.echo(f'Use with: export AWS_PROFILE={result_profile}')

--- a/nshm_toshi_client/config.py
+++ b/nshm_toshi_client/config.py
@@ -66,6 +66,16 @@ def _load_config_file() -> dict | None:
         return None
 
 
+_COGNITO_ENV_VARS = {
+    'cognito_domain': 'NZSHM22_TOSHI_COGNITO_DOMAIN',
+    'scientist_client_id': 'NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID',
+    'region': 'NZSHM22_TOSHI_COGNITO_REGION',
+    'user_pool_id': 'NZSHM22_TOSHI_COGNITO_USER_POOL_ID',
+    'identity_pool_id': 'NZSHM22_TOSHI_COGNITO_IDENTITY_POOL_ID',
+}
+COGNITO_CONFIG_KEYS = tuple(_COGNITO_ENV_VARS)
+
+
 def load_cognito_config() -> dict:
     """Resolve the Cognito config from env vars, with JSON-file fallback.
 
@@ -87,19 +97,12 @@ def load_cognito_config() -> dict:
     user_pool_id, identity_pool_id. Missing values are empty strings, except
     region which defaults to 'ap-southeast-2'.
     """
-    env_keys = {
-        'cognito_domain': 'NZSHM22_TOSHI_COGNITO_DOMAIN',
-        'scientist_client_id': 'NZSHM22_TOSHI_COGNITO_SCIENTIST_CLIENT_ID',
-        'region': 'NZSHM22_TOSHI_COGNITO_REGION',
-        'user_pool_id': 'NZSHM22_TOSHI_COGNITO_USER_POOL_ID',
-        'identity_pool_id': 'NZSHM22_TOSHI_COGNITO_IDENTITY_POOL_ID',
-    }
-    config = {k: os.getenv(env, '') for k, env in env_keys.items()}
+    config = {k: os.getenv(env, '') for k, env in _COGNITO_ENV_VARS.items()}
 
     # Always read the file so that all keys are picked up regardless of
     # which env vars are set.
     file_config = _load_config_file() or {}
-    for key in env_keys:
+    for key in _COGNITO_ENV_VARS:
         if not config[key] and file_config.get(key):
             config[key] = file_config[key]
 

--- a/nshm_toshi_client/toshi_client_base.py
+++ b/nshm_toshi_client/toshi_client_base.py
@@ -1,3 +1,18 @@
+"""GraphQL client base for the Toshi API, with JWT Bearer auth.
+
+``ToshiClientBase`` wraps ``gql.Client`` and injects an
+``Authorization: Bearer <jwt>`` header on every request.  The JWT (access_token)
+comes from one of three auto-detected sources (priority order): M2M token manager
+(``NZSHM22_TOSHI_M2M_SECRET_ARN`` + ``COGNITO_DOMAIN``), interactive credentials
+(``~/.toshi/credentials`` written by ``toshi-auth login``), or an explicit
+``auth_token`` / ``headers`` kwarg.
+
+This module is for Toshi **API** access only.  For AWS service access (S3,
+Batch, …) use ``nshm_toshi_client.aws.get_aws_session()`` — that returns a
+``boto3.Session`` via Cognito Identity Pool federation and is independent of
+this module.
+"""
+
 import logging
 import os
 

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1,0 +1,230 @@
+"""Tests for nshm_toshi_client.aws — get_aws_session() and typed exceptions."""
+
+import json
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+import botocore.exceptions
+
+from nshm_toshi_client.aws import (
+    ConfigIncompleteError,
+    IdentityPoolError,
+    NoCredentialsError,
+    RefreshFailedError,
+    get_aws_session,
+)
+
+from .test_credential_auth import _make_jwt
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FULL_CONFIG = {
+    'cognito_domain': 'toshi-auth.example.auth.ap-southeast-2.amazoncognito.com',
+    'scientist_client_id': 'scientist_client_id',
+    'region': 'ap-southeast-2',
+    'user_pool_id': 'ap-southeast-2_FAKE',
+    'identity_pool_id': 'ap-southeast-2:fake-pool',
+}
+
+
+def _make_cognito_identity_mock(identity_id='identity-1', access_key='AKIAFAKE', secret='secret', token='session'):
+    """Return a mock cognito-identity client that returns a successful STS response."""
+    mock = MagicMock()
+    mock.get_id.return_value = {'IdentityId': identity_id}
+    mock.get_credentials_for_identity.return_value = {
+        'Credentials': {
+            'AccessKeyId': access_key,
+            'SecretKey': secret,
+            'SessionToken': token,
+        }
+    }
+    return mock
+
+
+def _make_boto3_mock(cognito_identity_mock):
+    """Return a mock boto3 module whose client() returns cognito_identity_mock."""
+    mock_boto3 = MagicMock()
+    mock_boto3.client.return_value = cognito_identity_mock
+    return mock_boto3
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetAwsSessionHappyPath(unittest.TestCase):
+    def test_returns_boto3_session(self):
+        valid_id_token = _make_jwt({"exp": time.time() + 3600})
+        creds = {"access_token": _make_jwt({"exp": time.time() + 3600}), "id_token": valid_id_token}
+
+        mock_ci = _make_cognito_identity_mock()
+        mock_boto3 = _make_boto3_mock(mock_ci)
+
+        with (
+            patch('nshm_toshi_client.config.load_cognito_config', return_value=_FULL_CONFIG),
+            patch('nshm_toshi_client.auth.load_credentials', return_value=creds),
+            patch.dict('sys.modules', {'boto3': mock_boto3}),
+        ):
+            get_aws_session()
+
+        # boto3.Session was called with STS creds + region
+        mock_boto3.Session.assert_called_once()
+        call_kwargs = mock_boto3.Session.call_args[1]
+        self.assertEqual(call_kwargs['aws_access_key_id'], 'AKIAFAKE')
+        self.assertEqual(call_kwargs['aws_secret_access_key'], 'secret')
+        self.assertEqual(call_kwargs['aws_session_token'], 'session')
+        self.assertEqual(call_kwargs['region_name'], 'ap-southeast-2')
+
+    def test_logins_map_uses_id_token(self):
+        valid_id_token = _make_jwt({"exp": time.time() + 3600, "aud": "scientist_client_id"})
+        creds = {"access_token": _make_jwt({"exp": time.time() + 3600}), "id_token": valid_id_token}
+
+        mock_ci = _make_cognito_identity_mock()
+        mock_boto3 = _make_boto3_mock(mock_ci)
+
+        with (
+            patch('nshm_toshi_client.config.load_cognito_config', return_value=_FULL_CONFIG),
+            patch('nshm_toshi_client.auth.load_credentials', return_value=creds),
+            patch.dict('sys.modules', {'boto3': mock_boto3}),
+        ):
+            get_aws_session()
+
+        logins = mock_ci.get_id.call_args[1]['Logins']
+        provider_key = 'cognito-idp.ap-southeast-2.amazonaws.com/ap-southeast-2_FAKE'
+        self.assertIn(provider_key, logins)
+        self.assertEqual(logins[provider_key], valid_id_token)
+
+
+class TestGetAwsSessionConfigErrors(unittest.TestCase):
+    def test_raises_config_incomplete_missing_identity_pool(self):
+        config = {**_FULL_CONFIG, 'identity_pool_id': ''}
+        with patch('nshm_toshi_client.config.load_cognito_config', return_value=config):
+            with self.assertRaises(ConfigIncompleteError) as ctx:
+                get_aws_session()
+        self.assertIn('identity_pool_id', ctx.exception.missing)
+
+    def test_raises_config_incomplete_multiple_missing(self):
+        config = {**_FULL_CONFIG, 'region': '', 'user_pool_id': ''}
+        with patch('nshm_toshi_client.config.load_cognito_config', return_value=config):
+            with self.assertRaises(ConfigIncompleteError) as ctx:
+                get_aws_session()
+        self.assertIn('region', ctx.exception.missing)
+        self.assertIn('user_pool_id', ctx.exception.missing)
+
+    def test_config_incomplete_error_message_contains_key_name(self):
+        config = {**_FULL_CONFIG, 'identity_pool_id': ''}
+        with patch('nshm_toshi_client.config.load_cognito_config', return_value=config):
+            with self.assertRaises(ConfigIncompleteError) as ctx:
+                get_aws_session()
+        self.assertIn('identity_pool_id', str(ctx.exception))
+
+
+class TestGetAwsSessionCredentialErrors(unittest.TestCase):
+    def test_raises_no_credentials_when_missing(self):
+        with (
+            patch('nshm_toshi_client.config.load_cognito_config', return_value=_FULL_CONFIG),
+            patch('nshm_toshi_client.auth.load_credentials', return_value={}),
+        ):
+            with self.assertRaises(NoCredentialsError):
+                get_aws_session()
+
+    def test_raises_no_credentials_when_id_token_absent(self):
+        # access_token present but no id_token
+        valid_token = _make_jwt({"exp": time.time() + 3600})
+        creds = {"access_token": valid_token}
+        with (
+            patch('nshm_toshi_client.config.load_cognito_config', return_value=_FULL_CONFIG),
+            patch('nshm_toshi_client.auth.load_credentials', return_value=creds),
+        ):
+            with self.assertRaises(NoCredentialsError):
+                get_aws_session()
+
+    def test_raises_refresh_failed_when_token_expired_no_refresh(self):
+        expired_token = _make_jwt({"exp": time.time() - 100})
+        creds = {"access_token": expired_token}
+        with (
+            patch('nshm_toshi_client.config.load_cognito_config', return_value=_FULL_CONFIG),
+            patch('nshm_toshi_client.auth.load_credentials', return_value=creds),
+        ):
+            with self.assertRaises(RefreshFailedError):
+                get_aws_session()
+
+
+class TestGetAwsSessionRefreshOnExpiry(unittest.TestCase):
+    def test_refreshes_expired_token_and_federates(self):
+        expired_token = _make_jwt({"exp": time.time() - 100})
+        new_access = _make_jwt({"exp": time.time() + 3600})
+        new_id = _make_jwt({"exp": time.time() + 3600, "aud": "scientist_client_id"})
+        creds = {"access_token": expired_token, "id_token": expired_token, "refresh_token": "refresh_tok"}
+
+        refresh_response = MagicMock()
+        refresh_response.read.return_value = json.dumps({
+            "access_token": new_access,
+            "id_token": new_id,
+            "expires_in": 3600,
+        }).encode()
+        refresh_response.__enter__ = lambda s: s
+        refresh_response.__exit__ = MagicMock(return_value=False)
+
+        mock_ci = _make_cognito_identity_mock()
+        mock_boto3 = _make_boto3_mock(mock_ci)
+
+        with (
+            patch('nshm_toshi_client.config.load_cognito_config', return_value=_FULL_CONFIG),
+            patch('nshm_toshi_client.auth.load_credentials', return_value=creds),
+            patch('nshm_toshi_client.auth.save_credentials'),
+            patch('nshm_toshi_client.auth.urllib_request.urlopen', return_value=refresh_response),
+            patch.dict('sys.modules', {'boto3': mock_boto3}),
+        ):
+            get_aws_session()
+
+        # Verify the new id_token (post-refresh) was used in the Logins map
+        logins = mock_ci.get_id.call_args[1]['Logins']
+        provider_key = 'cognito-idp.ap-southeast-2.amazonaws.com/ap-southeast-2_FAKE'
+        self.assertEqual(logins[provider_key], new_id)
+
+
+class TestGetAwsSessionIdentityPoolError(unittest.TestCase):
+    def test_wraps_client_error_as_identity_pool_error(self):
+        valid_id_token = _make_jwt({"exp": time.time() + 3600})
+        creds = {"access_token": _make_jwt({"exp": time.time() + 3600}), "id_token": valid_id_token}
+
+        mock_ci = MagicMock()
+        error = botocore.exceptions.ClientError(
+            {'Error': {'Code': 'NotAuthorizedException', 'Message': 'Missing aud'}},
+            'GetId',
+        )
+        mock_ci.get_id.side_effect = error
+        mock_boto3 = _make_boto3_mock(mock_ci)
+
+        with (
+            patch('nshm_toshi_client.config.load_cognito_config', return_value=_FULL_CONFIG),
+            patch('nshm_toshi_client.auth.load_credentials', return_value=creds),
+            patch.dict('sys.modules', {'boto3': mock_boto3}),
+        ):
+            with self.assertRaises(IdentityPoolError):
+                get_aws_session()
+
+
+class TestExceptionHierarchy(unittest.TestCase):
+    def test_all_subclass_cognito_auth_error(self):
+        from nshm_toshi_client.aws import CognitoAuthError
+
+        self.assertTrue(issubclass(NoCredentialsError, CognitoAuthError))
+        self.assertTrue(issubclass(RefreshFailedError, CognitoAuthError))
+        self.assertTrue(issubclass(ConfigIncompleteError, CognitoAuthError))
+        self.assertTrue(issubclass(IdentityPoolError, CognitoAuthError))
+
+    def test_config_incomplete_stores_missing_list(self):
+        exc = ConfigIncompleteError(['region', 'identity_pool_id'])
+        self.assertEqual(exc.missing, ['region', 'identity_pool_id'])
+        self.assertIn('region', str(exc))
+        self.assertIn('identity_pool_id', str(exc))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -162,11 +162,13 @@ class TestGetAwsSessionRefreshOnExpiry(unittest.TestCase):
         creds = {"access_token": expired_token, "id_token": expired_token, "refresh_token": "refresh_tok"}
 
         refresh_response = MagicMock()
-        refresh_response.read.return_value = json.dumps({
-            "access_token": new_access,
-            "id_token": new_id,
-            "expires_in": 3600,
-        }).encode()
+        refresh_response.read.return_value = json.dumps(
+            {
+                "access_token": new_access,
+                "id_token": new_id,
+                "expires_in": 3600,
+            }
+        ).encode()
         refresh_response.__enter__ = lambda s: s
         refresh_response.__exit__ = MagicMock(return_value=False)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -593,106 +593,107 @@ class TestLogoutCommand(unittest.TestCase):
 
 
 class TestAwsCredsCommand(unittest.TestCase):
-    def test_aws_creds_not_logged_in(self):
-        with (
-            patch('nshm_toshi_client.cli.load_auth_config', return_value=FAKE_CONFIG),
-            patch('nshm_toshi_client.cli.load_credentials', return_value={}),
-        ):
-            runner = CliRunner()
-            result = runner.invoke(cli, ['aws-creds'])
+    """Tests for the aws-creds CLI command.
 
-        self.assertNotEqual(result.exit_code, 0)
-        self.assertIn("Not logged in", result.output)
+    The command now delegates to get_aws_session() (from nshm_toshi_client.aws)
+    and passes the resulting Session to get_aws_credentials(session, profile).
+    Refresh / credential logic is covered in tests/test_aws.py.
+    """
 
-    def test_aws_creds_expired_no_refresh(self):
-        expired_id_token = _make_jwt({"exp": time.time() - 100})
-        # id_token is present but expired, and no refresh_token — should error
-        creds = {"access_token": "some-access-token", "id_token": expired_id_token}
+    def _mock_session(self, access_key='AKIAFAKE', secret='secret', token='session', region='ap-southeast-2'):
+        """Return a mock boto3 Session with get_credentials().get_frozen_credentials()."""
+        frozen = MagicMock()
+        frozen.access_key = access_key
+        frozen.secret_key = secret
+        frozen.token = token
+        session = MagicMock()
+        session.get_credentials.return_value.get_frozen_credentials.return_value = frozen
+        session.region_name = region
+        return session
 
-        with (
-            patch('nshm_toshi_client.cli.load_auth_config', return_value=FAKE_CONFIG),
-            patch('nshm_toshi_client.cli.load_credentials', return_value=creds),
-        ):
-            runner = CliRunner()
-            result = runner.invoke(cli, ['aws-creds'])
+    # --- happy path ---
 
-        self.assertNotEqual(result.exit_code, 0)
-        self.assertIn("no refresh token", result.output)
-
-    def test_aws_creds_calls_get_aws_credentials(self):
-        valid_id_token = _make_jwt({"exp": time.time() + 3600})
-        creds = {"access_token": "some-access-token", "id_token": valid_id_token, "refresh_token": "refresh_tok"}
+    def test_aws_creds_calls_get_aws_credentials_with_session(self):
+        """aws-creds obtains a Session then delegates disk-write to get_aws_credentials."""
+        mock_session = self._mock_session()
 
         with (
-            patch('nshm_toshi_client.cli.load_auth_config', return_value=FAKE_CONFIG),
-            patch('nshm_toshi_client.cli.load_credentials', return_value=creds),
-            patch('nshm_toshi_client.cli.get_aws_credentials', return_value='toshi') as mock_get_aws,
+            patch('nshm_toshi_client.cli.get_aws_session', return_value=mock_session),
+            patch('nshm_toshi_client.cli.get_aws_credentials', return_value='myprofile') as mock_write,
         ):
             runner = CliRunner()
             result = runner.invoke(cli, ['aws-creds', '--profile', 'myprofile'])
 
-        self.assertEqual(result.exit_code, 0)
-        mock_get_aws.assert_called_once_with(FAKE_CONFIG, valid_id_token, 'myprofile')
+        self.assertEqual(result.exit_code, 0, result.output)
+        mock_write.assert_called_once_with(mock_session, 'myprofile')
         self.assertIn("AWS credentials saved", result.output)
 
-    def test_get_aws_credentials_happy_path(self):
-        from datetime import datetime, timezone
+    # --- error translation ---
 
+    def test_aws_creds_not_logged_in(self):
+        from nshm_toshi_client.aws import NoCredentialsError
+
+        with patch('nshm_toshi_client.cli.get_aws_session', side_effect=NoCredentialsError("No credentials")):
+            runner = CliRunner()
+            result = runner.invoke(cli, ['aws-creds'])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("No credentials", result.output)
+
+    def test_aws_creds_refresh_failed(self):
+        from nshm_toshi_client.aws import RefreshFailedError
+
+        with patch('nshm_toshi_client.cli.get_aws_session', side_effect=RefreshFailedError("Token expired")):
+            runner = CliRunner()
+            result = runner.invoke(cli, ['aws-creds'])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Token expired", result.output)
+
+    def test_aws_creds_config_incomplete(self):
+        from nshm_toshi_client.aws import ConfigIncompleteError
+
+        with patch(
+            'nshm_toshi_client.cli.get_aws_session',
+            side_effect=ConfigIncompleteError(['identity_pool_id']),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(cli, ['aws-creds'])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("identity_pool_id", result.output)
+
+    def test_aws_creds_identity_pool_error(self):
+        from nshm_toshi_client.aws import IdentityPoolError
+
+        with patch(
+            'nshm_toshi_client.cli.get_aws_session',
+            side_effect=IdentityPoolError("NotAuthorizedException"),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(cli, ['aws-creds'])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Identity Pool federation failed", result.output)
+
+    # --- get_aws_credentials unit test (file-write step) ---
+
+    def test_get_aws_credentials_writes_credentials_file(self):
+        """get_aws_credentials(session, profile) extracts creds from Session and writes ~/.aws/credentials."""
         from nshm_toshi_client.cli import get_aws_credentials
 
-        config = {**FAKE_CONFIG, 'identity_pool_id': 'ap-southeast-2:fake-pool'}
-        expiration = datetime(2030, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
-        mock_cognito_identity = MagicMock()
-        mock_cognito_identity.get_id.return_value = {'IdentityId': 'identity-1'}
-        mock_cognito_identity.get_credentials_for_identity.return_value = {
-            'Credentials': {
-                'AccessKeyId': 'AKIAFAKE',
-                'SecretKey': 'secret',
-                'SessionToken': 'session',
-                'Expiration': expiration,
-            }
-        }
-        mock_boto3 = MagicMock()
-        mock_boto3.client.return_value = mock_cognito_identity
+        mock_session = self._mock_session(access_key='AKIAFAKE', secret='secret', token='session_tok')
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            with (
-                patch.dict('sys.modules', {'boto3': mock_boto3}),
-                patch('nshm_toshi_client.cli.Path.home', return_value=Path(tmpdir)),
-            ):
-                profile = get_aws_credentials(config, 'fake-id-token', profile='toshi')
+            with patch('nshm_toshi_client.cli.Path.home', return_value=Path(tmpdir)):
+                profile = get_aws_credentials(mock_session, profile='toshi')
 
             self.assertEqual(profile, 'toshi')
             written = (Path(tmpdir) / '.aws' / 'credentials').read_text()
             self.assertIn('[toshi]', written)
             self.assertIn('aws_access_key_id = AKIAFAKE', written)
             self.assertIn('aws_secret_access_key = secret', written)
-            self.assertIn('aws_session_token = session', written)
-
-    def test_aws_creds_refreshes_expired_token(self):
-        expired_id_token = _make_jwt({"exp": time.time() - 100})
-        new_access_token = _make_jwt({"exp": time.time() + 3600})
-        new_id_token = _make_jwt({"exp": time.time() + 3600, "aud": "scientist_id"})
-        creds = {"access_token": "old-access", "id_token": expired_id_token, "refresh_token": "refresh_tok"}
-
-        with (
-            patch('nshm_toshi_client.cli.load_auth_config', return_value=FAKE_CONFIG),
-            patch('nshm_toshi_client.cli.load_credentials', return_value=creds),
-            patch(
-                'nshm_toshi_client.cli.refresh_token',
-                return_value={'access_token': new_access_token, 'id_token': new_id_token, 'expires_in': 3600},
-            ),
-            patch('nshm_toshi_client.cli.save_credentials') as mock_save,
-            patch('nshm_toshi_client.cli.get_aws_credentials', return_value='toshi') as mock_get_aws,
-        ):
-            runner = CliRunner()
-            result = runner.invoke(cli, ['aws-creds'])
-
-        self.assertEqual(result.exit_code, 0)
-        mock_get_aws.assert_called_once_with(FAKE_CONFIG, new_id_token, 'toshi')
-        saved_creds = mock_save.call_args[0][0]
-        self.assertEqual(saved_creds['id_token'], new_id_token)
-        self.assertEqual(saved_creds['access_token'], new_access_token)
+            self.assertIn('aws_session_token = session_tok', written)
 
 
 if __name__ == "__main__":

--- a/tests/test_credential_auth.py
+++ b/tests/test_credential_auth.py
@@ -276,18 +276,6 @@ class TestToshiCredentialAuthPublicMethods(unittest.TestCase):
 
         self.assertEqual(result, new_id)
 
-    # --- backwards compat: _get_token() still works ---
-
-    def test_private_get_token_still_works(self):
-        """_get_token() is kept as a private alias; existing internal call sites must not break."""
-        valid_token = _make_jwt({"exp": time.time() + 3600})
-        creds = {"access_token": valid_token, "refresh_token": "tok"}
-
-        with patch('nshm_toshi_client.auth.load_credentials', return_value=creds):
-            result = self._make_auth()._get_token()
-
-        self.assertEqual(result, valid_token)
-
 
 class TestToshiClientBaseWithCredentialAuth(unittest.TestCase):
     def test_auto_detects_credentials_file(self):

--- a/tests/test_credential_auth.py
+++ b/tests/test_credential_auth.py
@@ -200,9 +200,7 @@ class TestToshiCredentialAuthPublicMethods(unittest.TestCase):
         creds = {"access_token": expired, "refresh_token": "ref_tok"}
 
         refresh_response = MagicMock()
-        refresh_response.read.return_value = json.dumps(
-            {"access_token": new_token, "expires_in": 3600}
-        ).encode()
+        refresh_response.read.return_value = json.dumps({"access_token": new_token, "expires_in": 3600}).encode()
         refresh_response.__enter__ = lambda s: s
         refresh_response.__exit__ = MagicMock(return_value=False)
 

--- a/tests/test_credential_auth.py
+++ b/tests/test_credential_auth.py
@@ -134,14 +134,18 @@ class TestToshiCredentialAuth(unittest.TestCase):
         self.assertIn(f"client_id={self.CLIENT_ID}", req.data.decode())
 
     def test_raises_when_no_credentials(self):
+        from nshm_toshi_client.aws import NoCredentialsError
+
         with patch('nshm_toshi_client.auth.load_credentials', return_value={}):
             auth = ToshiCredentialAuth(self.DOMAIN, self.CLIENT_ID)
             mock_request = MagicMock()
             mock_request.headers = {}
-            with self.assertRaises(RuntimeError, msg="No credentials found"):
+            with self.assertRaises(NoCredentialsError):
                 auth(mock_request)
 
     def test_raises_when_expired_no_refresh_token(self):
+        from nshm_toshi_client.aws import RefreshFailedError
+
         expired_token = _make_jwt({"exp": time.time() - 100})
         creds = {"access_token": expired_token}
 
@@ -149,8 +153,140 @@ class TestToshiCredentialAuth(unittest.TestCase):
             auth = ToshiCredentialAuth(self.DOMAIN, self.CLIENT_ID)
             mock_request = MagicMock()
             mock_request.headers = {}
-            with self.assertRaises(RuntimeError, msg="no refresh token"):
+            with self.assertRaises(RefreshFailedError):
                 auth(mock_request)
+
+
+class TestToshiCredentialAuthPublicMethods(unittest.TestCase):
+    """Tests for the public get_token() and get_id_token() methods added in issue #50."""
+
+    DOMAIN = "https://toshi-auth.example.auth.ap-southeast-2.amazoncognito.com"
+    CLIENT_ID = "scientist_client_id"
+
+    def _make_auth(self):
+        return ToshiCredentialAuth(self.DOMAIN, self.CLIENT_ID)
+
+    # --- get_token() ---
+
+    def test_get_token_returns_access_token(self):
+        valid_token = _make_jwt({"exp": time.time() + 3600})
+        creds = {"access_token": valid_token, "refresh_token": "tok"}
+
+        with patch('nshm_toshi_client.auth.load_credentials', return_value=creds):
+            result = self._make_auth().get_token()
+
+        self.assertEqual(result, valid_token)
+
+    def test_get_token_raises_no_credentials_when_missing(self):
+        from nshm_toshi_client.aws import NoCredentialsError
+
+        with patch('nshm_toshi_client.auth.load_credentials', return_value={}):
+            with self.assertRaises(NoCredentialsError):
+                self._make_auth().get_token()
+
+    def test_get_token_raises_refresh_failed_when_expired_no_refresh(self):
+        from nshm_toshi_client.aws import RefreshFailedError
+
+        expired = _make_jwt({"exp": time.time() - 100})
+        creds = {"access_token": expired}
+
+        with patch('nshm_toshi_client.auth.load_credentials', return_value=creds):
+            with self.assertRaises(RefreshFailedError):
+                self._make_auth().get_token()
+
+    def test_get_token_refreshes_and_returns_new_token(self):
+        expired = _make_jwt({"exp": time.time() - 100})
+        new_token = _make_jwt({"exp": time.time() + 3600})
+        creds = {"access_token": expired, "refresh_token": "ref_tok"}
+
+        refresh_response = MagicMock()
+        refresh_response.read.return_value = json.dumps(
+            {"access_token": new_token, "expires_in": 3600}
+        ).encode()
+        refresh_response.__enter__ = lambda s: s
+        refresh_response.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch('nshm_toshi_client.auth.load_credentials', return_value=creds),
+            patch('nshm_toshi_client.auth.save_credentials'),
+            patch('nshm_toshi_client.auth.urllib_request.urlopen', return_value=refresh_response),
+        ):
+            result = self._make_auth().get_token()
+
+        self.assertEqual(result, new_token)
+
+    # --- get_id_token() ---
+
+    def test_get_id_token_returns_id_token(self):
+        valid_access = _make_jwt({"exp": time.time() + 3600})
+        valid_id = _make_jwt({"exp": time.time() + 3600, "aud": "scientist_client_id"})
+        creds = {"access_token": valid_access, "id_token": valid_id, "refresh_token": "tok"}
+
+        with patch('nshm_toshi_client.auth.load_credentials', return_value=creds):
+            result = self._make_auth().get_id_token()
+
+        self.assertEqual(result, valid_id)
+
+    def test_get_id_token_raises_no_credentials_when_id_token_absent(self):
+        from nshm_toshi_client.aws import NoCredentialsError
+
+        valid_access = _make_jwt({"exp": time.time() + 3600})
+        creds = {"access_token": valid_access}  # no id_token
+
+        with patch('nshm_toshi_client.auth.load_credentials', return_value=creds):
+            with self.assertRaises(NoCredentialsError):
+                self._make_auth().get_id_token()
+
+    def test_get_id_token_raises_no_credentials_when_creds_missing(self):
+        from nshm_toshi_client.aws import NoCredentialsError
+
+        with patch('nshm_toshi_client.auth.load_credentials', return_value={}):
+            with self.assertRaises(NoCredentialsError):
+                self._make_auth().get_id_token()
+
+    def test_get_id_token_raises_refresh_failed_when_expired_no_refresh(self):
+        from nshm_toshi_client.aws import RefreshFailedError
+
+        expired = _make_jwt({"exp": time.time() - 100})
+        creds = {"access_token": expired, "id_token": expired}
+
+        with patch('nshm_toshi_client.auth.load_credentials', return_value=creds):
+            with self.assertRaises(RefreshFailedError):
+                self._make_auth().get_id_token()
+
+    def test_get_id_token_refreshes_and_returns_new_id_token(self):
+        expired = _make_jwt({"exp": time.time() - 100})
+        new_access = _make_jwt({"exp": time.time() + 3600})
+        new_id = _make_jwt({"exp": time.time() + 3600, "aud": "scientist_client_id"})
+        creds = {"access_token": expired, "id_token": expired, "refresh_token": "ref_tok"}
+
+        refresh_response = MagicMock()
+        refresh_response.read.return_value = json.dumps(
+            {"access_token": new_access, "id_token": new_id, "expires_in": 3600}
+        ).encode()
+        refresh_response.__enter__ = lambda s: s
+        refresh_response.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch('nshm_toshi_client.auth.load_credentials', return_value=creds),
+            patch('nshm_toshi_client.auth.save_credentials'),
+            patch('nshm_toshi_client.auth.urllib_request.urlopen', return_value=refresh_response),
+        ):
+            result = self._make_auth().get_id_token()
+
+        self.assertEqual(result, new_id)
+
+    # --- backwards compat: _get_token() still works ---
+
+    def test_private_get_token_still_works(self):
+        """_get_token() is kept as a private alias; existing internal call sites must not break."""
+        valid_token = _make_jwt({"exp": time.time() + 3600})
+        creds = {"access_token": valid_token, "refresh_token": "tok"}
+
+        with patch('nshm_toshi_client.auth.load_credentials', return_value=creds):
+            result = self._make_auth()._get_token()
+
+        self.assertEqual(result, valid_token)
 
 
 class TestToshiClientBaseWithCredentialAuth(unittest.TestCase):


### PR DESCRIPTION
closes #50

# Background
This feature is intended to simplify the UX for runzi users by providing an in-memory boto3 session authenticated automatically. Rather than needing to perform:
```
toshi-auth login
toshi-auth aws-creds
```
They would now only need the `login` step.

In addition, a long-lived or interrupted runzi session can result in expired credentials. In this scenario the user may encounter STS (security-token-service -- temporary, limited-privilege access tokens used to authenticate with AWS) expired → AWS errors on next submit. User runs `aws-creds`; if access_token also expired, aws-creds errors and user runs `toshi-auth login`.

Instead, users authenticate once with `toshi-auth login`; runzi performs the Cognito Identity Pool federation on each invocation and never relies on ~/.aws/credentials being populated. The in-memory `boto3` session refreshes access_token via refresh_token silently.

`toshi-auth aws-creds` remains available as a side channel for any ad-hoc need (debugging, a one-off `aws s3 cp`, future tools that read `~/.aws/credentials`). The two paths coexist on the same `~/.toshi/credentials`.

# Code Changes
Add `nshm_toshi_client.aws` with a programmatic entry point for Cognito Identity Pool federation:

```
from nshm_toshi_client.aws import get_aws_session, CognitoAuthError
session = get_aws_session()  # -> boto3.Session
```
Typed exception hierarchy so callers can react to specific failures without string-matching:
`CognitoAuthError` (base)
`NoCredentialsError`   — ~/.toshi/credentials missing/empty
`RefreshFailedError`   — refresh token rejected
`ConfigIncompleteError` — missing env/file keys (.missing attr)
`IdentityPoolError`    — GetId/GetCredentialsForIdentity rejected

Public methods on ToshiCredentialAuth:
`get_token()`    -> access_token (raises `NoCredentialsError/RefreshFailedError`)
`get_id_token()` -> id_token     (raises `NoCredentialsError/RefreshFailedError`)

`cli.get_aws_credentials()` refactored: signature is now
```
get_aws_credentials(session, profile='toshi') -> str
```
(takes a `boto3.Session`, writes `~/.aws/credentials`, returns profile name). `toshi-auth aws-creds` behaviour is unchanged; it now calls `get_aws_session()` and delegates disk-write to `get_aws_credentials()`.