### PR TITLE
fix: derive AWS region from secret ARN in _fetch_m2m_credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- `ToshiTokenManager` now derives the AWS region from the Secrets Manager ARN, so `AWS_DEFAULT_REGION` is no longer required in batch environments. An optional `region=` kwarg on `ToshiTokenManager` (and `_fetch_m2m_credentials`) overrides the parsed value.
+
 ### Changed
 - `cli.get_aws_credentials()` passes `id_token` to `GetId` / `GetCredentialsForIdentity` Logins instead of `access_token`.
 - All Cognito keys try env first and fall back to `~/.toshi/auth_config.json` file.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,7 +25,9 @@ using the runtime's IAM role. The secret value must be JSON:
 ```
 
 Grant your runtime IAM role `secretsmanager:GetSecretValue` on the secret ARN,
-then set these env vars and the client configures itself automatically:
+then set these env vars and the client configures itself automatically. The AWS
+region is derived automatically from the secret ARN, so `AWS_DEFAULT_REGION`
+does not need to be set for the M2M path.
 
 ```bash
 export NZSHM22_TOSHI_API_URL=https://example-api-url.com/graphql
@@ -57,6 +59,7 @@ from nshm_toshi_client import ToshiFile
 mgr = ToshiTokenManager(
     cognito_domain="https://toshi-auth.example.auth.ap-southeast-2.amazoncognito.com",
     secret_arn="arn:aws:secretsmanager:ap-southeast-2:123456789012:secret:toshi-m2m-AbCdEf",
+    # region= is optional; derived from the ARN when not given
 )
 api = ToshiFile(
     "https://example-api-url.com/graphql",

--- a/nshm_toshi_client/auth.py
+++ b/nshm_toshi_client/auth.py
@@ -15,14 +15,28 @@ CREDENTIALS_PATH = Path.home() / '.toshi' / 'credentials'
 logger = logging.getLogger(__name__)
 
 
-def _fetch_m2m_credentials(secret_arn: str) -> tuple[str, str]:
+def _region_from_arn(secret_arn: str) -> str:
+    """Extract the AWS region from a Secrets Manager ARN.
+
+    ARN format: arn:aws:secretsmanager:<region>:<account>:secret:<name>
+    """
+    parts = secret_arn.split(':')
+    if len(parts) < 6 or not parts[3]:
+        raise ValueError(f"Cannot parse region from ARN: {secret_arn!r}")
+    return parts[3]
+
+
+def _fetch_m2m_credentials(secret_arn: str, region: str | None = None) -> tuple[str, str]:
     """Fetch (client_id, client_secret) from AWS Secrets Manager.
 
     The secret value must be a JSON object with `client_id` and `client_secret` keys.
+    Region is derived from the ARN when not supplied explicitly.
     """
     import boto3  # optional dep, only required for this path
 
-    sm = boto3.client('secretsmanager')
+    if region is None:
+        region = _region_from_arn(secret_arn)
+    sm = boto3.client('secretsmanager', region_name=region)
     payload = json.loads(sm.get_secret_value(SecretId=secret_arn)['SecretString'])
     return payload['client_id'], payload['client_secret']
 
@@ -37,19 +51,20 @@ class ToshiTokenManager:
     Thread-safe: a single instance can be shared across threads.
     """
 
-    def __init__(self, *, cognito_domain: str, secret_arn: str | None = None):
+    def __init__(self, *, cognito_domain: str, secret_arn: str | None = None, region: str | None = None):
         """
         Args:
             cognito_domain: Cognito hosted UI domain,
                 e.g. https://toshi-auth.xxx.auth.ap-southeast-2.amazoncognito.com
             secret_arn: AWS Secrets Manager ARN holding a JSON blob with
                 `client_id` and `client_secret`. Falls back to NZSHM22_TOSHI_M2M_SECRET_ARN.
+            region: AWS region for Secrets Manager. Derived from `secret_arn` when not given.
         """
         if secret_arn is None:
             secret_arn = os.environ.get('NZSHM22_TOSHI_M2M_SECRET_ARN') or None
         if not secret_arn:
             raise ValueError("M2M credentials not configured: pass secret_arn or set NZSHM22_TOSHI_M2M_SECRET_ARN.")
-        self._client_id, self._client_secret = _fetch_m2m_credentials(secret_arn)
+        self._client_id, self._client_secret = _fetch_m2m_credentials(secret_arn, region=region)
         self._domain = cognito_domain.rstrip('/')
         self._token: str | None = None
         self._expires_at: float = 0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,3 +33,16 @@ def mock_secrets_manager(client_id="test-client-id", client_secret="test-client-
     mock_boto3.client.return_value = sm
     with patch.dict('sys.modules', {'boto3': mock_boto3}):
         yield sm
+
+
+@contextmanager
+def mock_secrets_manager_with_boto3(client_id="test-client-id", client_secret="test-client-secret"):
+    """Like mock_secrets_manager but yields (sm, mock_boto3) for call-arg assertions."""
+    sm = MagicMock()
+    sm.get_secret_value.return_value = {
+        'SecretString': json.dumps({'client_id': client_id, 'client_secret': client_secret}),
+    }
+    mock_boto3 = MagicMock()
+    mock_boto3.client.return_value = sm
+    with patch.dict('sys.modules', {'boto3': mock_boto3}):
+        yield sm, mock_boto3

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,16 +7,38 @@ from unittest.mock import MagicMock, patch
 
 import requests_mock
 
-from nshm_toshi_client.auth import ToshiM2MAuth, ToshiTokenManager, _fetch_m2m_credentials
+from nshm_toshi_client.auth import ToshiM2MAuth, ToshiTokenManager, _fetch_m2m_credentials, _region_from_arn
 from nshm_toshi_client.toshi_client_base import ToshiClientBase
 
-from .conftest import mock_secrets_manager
+from .conftest import mock_secrets_manager, mock_secrets_manager_with_boto3
 from .conftest import mock_urlopen as _mock_urlopen
 
 COGNITO_DOMAIN = "https://toshi-auth.example.auth.ap-southeast-2.amazoncognito.com"
 SECRET_ARN = "arn:aws:secretsmanager:ap-southeast-2:123456789012:secret:toshi-m2m-AbCdEf"
 
 TOKEN_RESPONSE = json.dumps({"access_token": "fake.jwt.token", "expires_in": 3600}).encode()
+
+
+class TestRegionFromArn(unittest.TestCase):
+    def test_extracts_region(self):
+        self.assertEqual(
+            _region_from_arn("arn:aws:secretsmanager:ap-southeast-2:123456789012:secret:toshi-m2m-AbCdEf"),
+            "ap-southeast-2",
+        )
+
+    def test_extracts_us_east_1(self):
+        self.assertEqual(
+            _region_from_arn("arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret"),
+            "us-east-1",
+        )
+
+    def test_malformed_arn_raises(self):
+        with self.assertRaises(ValueError):
+            _region_from_arn("not-an-arn")
+
+    def test_arn_with_empty_region_raises(self):
+        with self.assertRaises(ValueError):
+            _region_from_arn("arn:aws:secretsmanager::123456789012:secret:name")
 
 
 class TestFetchM2MCredentials(unittest.TestCase):
@@ -26,6 +48,16 @@ class TestFetchM2MCredentials(unittest.TestCase):
         self.assertEqual(client_id, "cid")
         self.assertEqual(client_secret, "csec")
         sm.get_secret_value.assert_called_once_with(SecretId=SECRET_ARN)
+
+    def test_region_parsed_from_arn(self):
+        with mock_secrets_manager_with_boto3() as (sm, mock_boto3):
+            _fetch_m2m_credentials(SECRET_ARN)
+        mock_boto3.client.assert_called_once_with('secretsmanager', region_name='ap-southeast-2')
+
+    def test_region_kwarg_overrides_arn(self):
+        with mock_secrets_manager_with_boto3() as (sm, mock_boto3):
+            _fetch_m2m_credentials(SECRET_ARN, region='us-east-1')
+        mock_boto3.client.assert_called_once_with('secretsmanager', region_name='us-east-1')
 
 
 class TestToshiTokenManager(unittest.TestCase):
@@ -86,6 +118,11 @@ class TestToshiTokenManager(unittest.TestCase):
             manager.get_token()  # should use cache
 
         self.assertEqual(mock_open.call_count, 1)
+
+    def test_region_kwarg_propagates_to_boto3(self):
+        with mock_secrets_manager_with_boto3() as (sm, mock_boto3):
+            ToshiTokenManager(cognito_domain=COGNITO_DOMAIN, secret_arn=SECRET_ARN, region='eu-west-1')
+        mock_boto3.client.assert_called_once_with('secretsmanager', region_name='eu-west-1')
 
 
 class TestToshiM2MAuth(unittest.TestCase):

--- a/tests/test_credential_auth.py
+++ b/tests/test_credential_auth.py
@@ -318,7 +318,10 @@ class TestSubclassKwargsPassthrough(unittest.TestCase):
         from .conftest import mock_secrets_manager
 
         with mock_secrets_manager():
-            return ToshiTokenManager(cognito_domain="https://auth.example.com", secret_arn="arn:fake")
+            return ToshiTokenManager(
+                cognito_domain="https://auth.example.com",
+                secret_arn="arn:aws:secretsmanager:<region>:<account>:secret:<name>",
+            )
 
     def test_toshi_file_accepts_token_manager(self):
         from nshm_toshi_client.toshi_file import ToshiFile


### PR DESCRIPTION
closes #53 

When retrieving secrets for M2M auth `boto3.client('secretsmanager')` previously relied on `AWS_DEFAULT_REGION`, which is not set in all batch environments. Every other boto3 call in the repo passes region_name= explicitly; this brings auth.py into line.

  Changes:
  - Add `_region_from_arn()` helper (raises `ValueError` on malformed ARNs)
  - `_fetch_m2m_credentials()` derives region from ARN; optional region= kwarg overrides
  - `ToshiTokenManager.__init__()` gains optional region= kwarg, threads through to fetch

  Tests:
  - TestRegionFromArn: 4 tests for helper (happy path x2, malformed, empty region)
  - TestFetchM2MCredentials: assert boto3.client called with correct region_name=
  - TestToshiTokenManager: assert region kwarg propagates to boto3

  Docs: note AWS_DEFAULT_REGION is no longer needed for M2M path