### PR TITLE
fix: centralise NZSHM22_TOSHI_M2M_SECRET_ARN access via config.M2M_SECRET_ARN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-05-29
+
+### Changed
+- `auth.py` and `toshi_client_base.py` now reference `config.M2M_SECRET_ARN` instead of reading `NZSHM22_TOSHI_M2M_SECRET_ARN` from `os.environ` directly, consolidating env-var access in `config.py`.
+
 ## [1.3.0] - 2026-05-29
 
 ### Added

--- a/nshm_toshi_client/auth.py
+++ b/nshm_toshi_client/auth.py
@@ -1,7 +1,6 @@
 import base64
 import json
 import logging
-import os
 import threading
 import time
 from pathlib import Path
@@ -9,6 +8,8 @@ from urllib import parse
 from urllib import request as urllib_request
 
 from requests.auth import AuthBase
+
+from nshm_toshi_client import config
 
 CREDENTIALS_PATH = Path.home() / '.toshi' / 'credentials'
 
@@ -97,7 +98,7 @@ class ToshiTokenManager:
             region: AWS region for Secrets Manager. Derived from `secret_arn` when not given.
         """
         if secret_arn is None:
-            secret_arn = os.environ.get('NZSHM22_TOSHI_M2M_SECRET_ARN') or None
+            secret_arn = config.M2M_SECRET_ARN or None
         if not secret_arn:
             raise ValueError("M2M credentials not configured: pass secret_arn or set NZSHM22_TOSHI_M2M_SECRET_ARN.")
         self._client_id, self._client_secret = _fetch_m2m_credentials(secret_arn, region=region)

--- a/nshm_toshi_client/toshi_client_base.py
+++ b/nshm_toshi_client/toshi_client_base.py
@@ -14,13 +14,12 @@ this module.
 """
 
 import logging
-import os
 
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 
+from nshm_toshi_client import config
 from nshm_toshi_client.auth import CREDENTIALS_PATH, ToshiCredentialAuth, ToshiM2MAuth, ToshiTokenManager
-from nshm_toshi_client.config import load_cognito_config
 
 logger = logging.getLogger(__name__)
 
@@ -83,11 +82,11 @@ class ToshiClientBase:
             and NZSHM22_TOSHI_M2M_SECRET_ARN + NZSHM22_TOSHI_COGNITO_DOMAIN are set, one is
             created automatically (credentials fetched from AWS Secrets Manager).
         """
-        cognito = load_cognito_config()
+        cognito = config.load_cognito_config()
         cognito_domain = cognito['cognito_domain']
         scientist_client_id = cognito['scientist_client_id']
 
-        secret_arn = os.environ.get('NZSHM22_TOSHI_M2M_SECRET_ARN')
+        secret_arn = config.M2M_SECRET_ARN or None
         if token_manager is None and secret_arn and cognito_domain:
             if auth_token is not None:
                 logger.warning(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -66,13 +66,13 @@ class TestToshiTokenManager(unittest.TestCase):
             return ToshiTokenManager(cognito_domain=COGNITO_DOMAIN, secret_arn=SECRET_ARN)
 
     def test_requires_secret_arn(self):
-        with patch.dict('os.environ', {'NZSHM22_TOSHI_M2M_SECRET_ARN': ''}):
+        with patch('nshm_toshi_client.config.M2M_SECRET_ARN', ''):
             with self.assertRaises(ValueError) as ctx:
                 ToshiTokenManager(cognito_domain=COGNITO_DOMAIN)
             self.assertIn("M2M credentials not configured", str(ctx.exception))
 
     def test_reads_secret_arn_from_env(self):
-        with patch.dict('os.environ', {'NZSHM22_TOSHI_M2M_SECRET_ARN': SECRET_ARN}):
+        with patch('nshm_toshi_client.config.M2M_SECRET_ARN', SECRET_ARN):
             with mock_secrets_manager(client_id="env-cid", client_secret="env-csec"):
                 manager = ToshiTokenManager(cognito_domain=COGNITO_DOMAIN)
         self.assertEqual(manager._client_id, "env-cid")


### PR DESCRIPTION
closes #55 

## Summary

- `auth.py` and `toshi_client_base.py` were each reading `NZSHM22_TOSHI_M2M_SECRET_ARN` directly from `os.environ`, duplicating a lookup that `config.py` already centralises as the `M2M_SECRET_ARN` constant.
- Both consumers now reference `config.M2M_SECRET_ARN`; `import os` is removed from both files.
- Two tests in `test_auth.py` updated to patch `nshm_toshi_client.config.M2M_SECRET_ARN` instead of `os.environ`.

## Test plan

- [ ] `uv run pytest tests/` — all 108 tests pass
- [ ] `uv run tox -e lint` — no ruff or mypy issues